### PR TITLE
Allow extracting version information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Features
 - update buildGoModule's vendorSha256/modSha256
 - build and run the resulting package (see `--build`, `--run` or `--shell` flag)
 - commit updated files (see `--commit` flag)
+- run package tests (see `--test` flag)
 
 Installation
 ------------
@@ -85,12 +86,21 @@ To only update sources hashes without updating the version:
 
    $ nix-update --version=skip nixpkgs-review
 
-With the `--shell`, `--build` and `--run` flags the update can be tested
+To extract version information from versions with prefixes or suffixes, a regex
+can be used
+
+::
+
+   $ nix-update jq --version-regex 'jq-(.*)'
+
+With the `--shell`, `--build`, `--test` and `--run` flags the update can be tested
 
 ::
 
    # Also runs nix-build
    $ nix-update --build nixpkgs-review
+   # Also runs nix-build nixpkgs-review.tests
+   $ nix-update --test nixpkgs-review
    # Also runs nix-shell
    $ nix-update --shell nixpkgs-review
    # Also runs nix run

--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -27,6 +27,12 @@ def parse_args() -> Options:
         "--commit", action="store_true", help="Commit the updated package"
     )
     parser.add_argument(
+        "-vr",
+        "--version-regex",
+        help="Regex to extract version with, i.e. 'jq-(.*)'",
+        default="(.*)",
+    )
+    parser.add_argument(
         "--run",
         action="store_true",
         help="provide a shell based on `nix run` with the package in $PATH",
@@ -48,6 +54,7 @@ def parse_args() -> Options:
         version=args.version,
         attribute=args.attribute,
         test=args.test,
+        version_regex=args.version_regex,
     )
 
 

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -11,3 +11,4 @@ class Options:
     run: bool
     build: bool
     test: bool
+    version_regex: str

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -93,7 +93,7 @@ def update_cargo_sha256_hash(opts: Options, filename: str, current_hash: str) ->
     replace_hash(filename, current_hash, target_hash)
 
 
-def update_version(package: Package, version: str) -> bool:
+def update_version(package: Package, version: str, version_regex: str) -> bool:
     if version == "auto":
         if not package.url:
             if package.urls:
@@ -102,7 +102,7 @@ def update_version(package: Package, version: str) -> bool:
                 raise UpdateError(
                     "Could not find a url in the derivations src attribute"
                 )
-        new_version = fetch_latest_version(url)
+        new_version = fetch_latest_version(url, version_regex)
     else:
         new_version = version
     package.new_version = new_version
@@ -123,7 +123,7 @@ def update(opts: Options) -> Package:
     update_hash = True
 
     if opts.version != "skip":
-        update_hash = update_version(package, opts.version)
+        update_hash = update_version(package, opts.version, opts.version_regex)
 
     if update_hash:
         update_src_hash(opts, package.filename, package.hash)

--- a/nix_update/utils.py
+++ b/nix_update/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -30,3 +31,13 @@ def run(
 ) -> "subprocess.CompletedProcess[str]":
     info("$ " + " ".join(command))
     return subprocess.run(command, cwd=cwd, check=check, text=True, stdout=stdout)
+
+
+def extract_version(version: str, version_regex: str) -> Optional[str]:
+    pattern = re.compile(version_regex)
+    match = re.match(pattern, version)
+    if match is not None:
+        group = match.group(1)
+        if group is not None:
+            return group
+    return None

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from ..errors import VersionError
+from ..utils import extract_version
 from .github import fetch_github_version
 from .gitlab import fetch_gitlab_version
 from .pypi import fetch_pypi_version
@@ -24,14 +25,16 @@ fetchers = [
 ]
 
 
-def fetch_latest_version(url_str: str) -> str:
+def fetch_latest_version(url_str: str, version_regex: str) -> str:
     url = urlparse(url_str)
 
     for fetcher in fetchers:
-        version = fetcher(url)
+        version = fetcher(url, version_regex)
         if version is not None:
-            return version
+            extracted = extract_version(version, version_regex)
+            if extracted is not None:
+                return extracted
 
     raise VersionError(
-        "Please specify the version. We can only get the latest version from github/gitlab/pypi projects right now"
+        "Please specify the version. We can only get the latest version from github/gitlab/pypi/rubygems projects right now"
     )

--- a/nix_update/version/gitlab.py
+++ b/nix_update/version/gitlab.py
@@ -5,14 +5,14 @@ from typing import Optional
 from urllib.parse import ParseResult
 
 from ..errors import VersionError
-from ..utils import info
+from ..utils import extract_version, info
 
 GITLAB_API = re.compile(
     r"http(s)?://(?P<domain>[^/]+)/api/v4/projects/(?P<project_id>[^/]*)/repository/archive.tar.gz\?sha=(?P<version>.+)"
 )
 
 
-def fetch_gitlab_version(url: ParseResult) -> Optional[str]:
+def fetch_gitlab_version(url: ParseResult, version_regex: str) -> Optional[str]:
     match = GITLAB_API.match(url.geturl())
     if not match:
         return None
@@ -28,8 +28,10 @@ def fetch_gitlab_version(url: ParseResult) -> Optional[str]:
         if tag["release"]:
             name = tag["name"]
             assert isinstance(name, str)
-            return name
+            extracted = extract_version(name, version_regex)
+            if extracted is not None:
+                return extracted
     # if no release is found, use latest tag
     name = tags[0]["name"]
     assert isinstance(name, str)
-    return name
+    return extract_version(name, version_regex)

--- a/nix_update/version/pypi.py
+++ b/nix_update/version/pypi.py
@@ -3,10 +3,10 @@ import urllib.request
 from typing import Optional
 from urllib.parse import ParseResult
 
-from ..utils import info
+from ..utils import extract_version, info
 
 
-def fetch_pypi_version(url: ParseResult) -> Optional[str]:
+def fetch_pypi_version(url: ParseResult, version_regex: str) -> Optional[str]:
     if url.netloc != "pypi":
         return None
     parts = url.path.split("/")
@@ -17,4 +17,4 @@ def fetch_pypi_version(url: ParseResult) -> Optional[str]:
     data = json.loads(resp.read())
     version = data["info"]["version"]
     assert isinstance(version, str)
-    return version
+    return extract_version(version, version_regex)

--- a/nix_update/version/rubygems.py
+++ b/nix_update/version/rubygems.py
@@ -4,10 +4,10 @@ from urllib.parse import ParseResult
 import json
 
 from ..errors import VersionError
-from ..utils import info
+from ..utils import extract_version, info
 
 
-def fetch_rubygem_version(url: ParseResult) -> Optional[str]:
+def fetch_rubygem_version(url: ParseResult, version_regex: str) -> Optional[str]:
     if url.netloc != "rubygems.org":
         return None
     parts = url.path.split("/")
@@ -23,7 +23,9 @@ def fetch_rubygem_version(url: ParseResult) -> Optional[str]:
         if not version["prerelease"]:
             number = version["number"]
             assert isinstance(number, str)
-            return number
+            extracted = extract_version(number, version_regex)
+            if extracted is not None:
+                return extracted
     number = versions[0]["number"]
     assert isinstance(number, str)
-    return number
+    return extract_version(number, version_regex)


### PR DESCRIPTION
This can be used to remove tag prefixes, suffixes or similar

Closes #29


Allows updates of packages like `jq`.

Before:
```
λ nix-update jq --build --test
$ nix eval --json --impure --experimental-features nix-command --expr (with import ./. {};
    let
      pkg = jq;
      raw_version_position = builtins.unsafeGetAttrPos "version" pkg;

      position = if pkg ? isRubyGem then
        raw_version_position
      else
        builtins.unsafeGetAttrPos "src" pkg;
    in {
      name = pkg.name;
      old_version = (builtins.parseDrvName pkg.name).version;
      inherit raw_version_position;
      filename = position.file;
      line = position.line;
      urls = pkg.src.urls or null;
      url = pkg.src.url or null;
      rev = pkg.src.url.rev or null;
      hash = pkg.src.outputHash;
      mod_sha256 = pkg.modSha256 or null;
      vendor_sha256 = pkg.vendorSha256 or null;
      cargo_sha256 = pkg.cargoSha256 or null;
      tests = pkg.passthru.tests or null;
    })
fetch https://github.com/stedolan/jq/releases.atom
Update 1.6 -> jq-1.6 in /opt/dev/upstream_nix/pkgs/development/tools/jq/default.nix
$ nix-prefetch (import ./. {}).jq
The package jq-jq-1.6 will be fetched as follows:
> fetchurl {
>   sha256 = "0wmapfskhzfwranf6515nzmm84r7kwljgfs7dg6bjgxakbicis2x";
>   url = "https://github.com/stedolan/jq/releases/download/jq-jq-1.6/jq-jq-1.6.tar.gz";
> }

trying https://github.com/stedolan/jq/releases/download/jq-jq-1.6/jq-jq-1.6.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
error: cannot download jq-jq-1.6.tar.gz from any mirror
builder for '/nix/store/vcdpbs5dhvgsvx0snkb453dzcf6hb48j-jq-jq-1.6.tar.gz.drv' failed with exit code 1
error: build of '/nix/store/vcdpbs5dhvgsvx0snkb453dzcf6hb48j-jq-jq-1.6.tar.gz.drv' failed
Traceback (most recent call last):
  File "/nix/store/n83gwcnyyz7gk0q3r6r1n9l8mjwvrjgd-nix-update/bin/.nix-update-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/n83gwcnyyz7gk0q3r6r1n9l8mjwvrjgd-nix-update/lib/python3.8/site-packages/nix_update/__init__.py", line 172, in main
    package = update(options)
  File "/nix/store/n83gwcnyyz7gk0q3r6r1n9l8mjwvrjgd-nix-update/lib/python3.8/site-packages/nix_update/update.py", line 129, in update
    update_src_hash(opts, package.filename, package.hash)
  File "/nix/store/n83gwcnyyz7gk0q3r6r1n9l8mjwvrjgd-nix-update/lib/python3.8/site-packages/nix_update/update.py", line 74, in update_src_hash
    target_hash = nix_prefetch([f"(import {opts.import_path} {{}}).{opts.attribute}"])
  File "/nix/store/n83gwcnyyz7gk0q3r6r1n9l8mjwvrjgd-nix-update/lib/python3.8/site-packages/nix_update/update.py", line 69, in nix_prefetch
    res = run(["nix-prefetch"] + cmd)
  File "/nix/store/n83gwcnyyz7gk0q3r6r1n9l8mjwvrjgd-nix-update/lib/python3.8/site-packages/nix_update/utils.py", line 32, in run
    return subprocess.run(command, cwd=cwd, check=check, text=True, stdout=stdout)
  File "/nix/store/i9lzacdfrwlj1ayw551c016s0fq71p7j-python3-3.8.6/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix-prefetch', '(import ./. {}).jq']' returned non-zero exit status 1.
```

After:
```
λ nix-update jq --build --test -ve 'jq-(.*)'
$ nix eval --json --impure --experimental-features nix-command --expr (with import ./. {};
    let
      pkg = jq;
      raw_version_position = builtins.unsafeGetAttrPos "version" pkg;

      position = if pkg ? isRubyGem then
        raw_version_position
      else
        builtins.unsafeGetAttrPos "src" pkg;
    in {
      name = pkg.name;
      old_version = (builtins.parseDrvName pkg.name).version;
      inherit raw_version_position;
      filename = position.file;
      line = position.line;
      urls = pkg.src.urls or null;
      url = pkg.src.url or null;
      rev = pkg.src.url.rev or null;
      hash = pkg.src.outputHash;
      mod_sha256 = pkg.modSha256 or null;
      vendor_sha256 = pkg.vendorSha256 or null;
      cargo_sha256 = pkg.cargoSha256 or null;
      tests = pkg.passthru.tests or null;
    })
fetch https://github.com/stedolan/jq/releases.atom
Not updating version, already 1.6
$ nix build --experimental-features nix-command -f ./. jq
$ nix-build -A jq.tests.jq
```