### PR TITLE
Fix pattern replacements

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -1,5 +1,4 @@
 import fileinput
-import re
 from typing import List
 import subprocess
 
@@ -61,7 +60,7 @@ def replace_hash(filename: str, current: str, target: str) -> None:
     if to_sri(current) != normalized_hash:
         with fileinput.FileInput(filename, inplace=True) as f:
             for line in f:
-                line = re.sub(current, normalized_hash, line)
+                line = line.replace(current, normalized_hash)
                 print(line, end="")
 
 


### PR DESCRIPTION
SRI hashes containing regex characters such as '+'
break the replacement logic intended with `re.sub`
Use strict string replacements instead

---

nixpkgs@f0bce04b991

Before:
```
λ nix-update python3Packages.botocore --commit --build
$ git -C ./. diff --staged
$ nix eval --json --impure --experimental-features nix-command --expr (with import ./. {};
    let
      pkg = python3Packages.botocore;
      raw_version_position = builtins.unsafeGetAttrPos "version" pkg;

      position = if pkg ? isRubyGem then
        raw_version_position
      else
        builtins.unsafeGetAttrPos "src" pkg;
    in {
      name = pkg.name;
      old_version = (builtins.parseDrvName pkg.name).version;
      inherit raw_version_position;
      filename = position.file;
      line = position.line;
      urls = pkg.src.urls or null;
      url = pkg.src.url or null;
      rev = pkg.src.url.rev or null;
      hash = pkg.src.outputHash;
      mod_sha256 = pkg.modSha256 or null;
      vendor_sha256 = pkg.vendorSha256 or null;
      cargo_sha256 = pkg.cargoSha256 or null;
      tests = pkg.passthru.tests or null;
    })
fetch https://pypi.org/pypi/botocore/json
Update 1.19.40 -> 1.19.41 in /opt/dev/upstream_nix/pkgs/development/python-modules/botocore/default.nix
True
$ nix-prefetch (import ./. {}).python3Packages.botocore
The package python3.8-botocore-1.19.41 will be fetched as follows:
> fetchurl {
>   hash = "";
>   sha256 = "sha256-6/qICsjLgTLcZleQK/VG9SzyxDJ4Vw9gyPig+JRVZVU=";
>   url = "mirror://pypi/b/botocore/botocore-1.19.41.tar.gz";
> }

sha256-VKillJeoO6LYn7lPht0HtiLXtfHW6ZJSIuu8ResNY6w=
$ nix build --experimental-features nix-command -f ./. python3Packages.botocore
error: --- Error ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix
hash mismatch in fixed-output derivation '/nix/store/72kjmki3sz9plg0k7k3jgxz3x2mhf8a8-botocore-1.19.41.tar.gz.drv':
  specified: sha256-6/qICsjLgTLcZleQK/VG9SzyxDJ4Vw9gyPig+JRVZVU=
     got:    sha256-VKillJeoO6LYn7lPht0HtiLXtfHW6ZJSIuu8ResNY6w=
error: --- Error ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix
1 dependencies of derivation '/nix/store/r9fmd2fpmjd3p7zhyq4kasb2qxw1dzn3-python3.8-botocore-1.19.41.drv' failed to build
$ git -C ./. add /opt/dev/upstream_nix/pkgs/development/python-modules/botocore/default.nix
$ git -C ./. diff --staged
$ git -C ./. commit --verbose --message python3Packages.botocore: 1.19.40 -> 1.19.41
[master 6a4895f8ccf] python3Packages.botocore: 1.19.40 -> 1.19.41
 1 file changed, 1 insertion(+), 1 deletion(-)
```

After:
```
λ nix-update python3Packages.botocore --commit --build
$ git -C ./. diff --staged
$ nix eval --json --impure --experimental-features nix-command --expr (with import ./. {};
    let
      pkg = python3Packages.botocore;
      raw_version_position = builtins.unsafeGetAttrPos "version" pkg;

      position = if pkg ? isRubyGem then
        raw_version_position
      else
        builtins.unsafeGetAttrPos "src" pkg;
    in {
      name = pkg.name;
      old_version = (builtins.parseDrvName pkg.name).version;
      inherit raw_version_position;
      filename = position.file;
      line = position.line;
      urls = pkg.src.urls or null;
      url = pkg.src.url or null;
      rev = pkg.src.url.rev or null;
      hash = pkg.src.outputHash;
      mod_sha256 = pkg.modSha256 or null;
      vendor_sha256 = pkg.vendorSha256 or null;
      cargo_sha256 = pkg.cargoSha256 or null;
      tests = pkg.passthru.tests or null;
    })
fetch https://pypi.org/pypi/botocore/json
Update 1.19.40 -> 1.19.41 in /opt/dev/upstream_nix/pkgs/development/python-modules/botocore/default.nix
$ nix-prefetch (import ./. {}).python3Packages.botocore
The package python3.8-botocore-1.19.41 will be fetched as follows:
> fetchurl {
>   hash = "";
>   sha256 = "sha256-6/qICsjLgTLcZleQK/VG9SzyxDJ4Vw9gyPig+JRVZVU=";
>   url = "mirror://pypi/b/botocore/botocore-1.19.41.tar.gz";
> }

$ nix build --experimental-features nix-command -f ./. python3Packages.botocore
$ git -C ./. add /opt/dev/upstream_nix/pkgs/development/python-modules/botocore/default.nix
$ git -C ./. diff --staged
$ git -C ./. commit --verbose --message python3Packages.botocore: 1.19.40 -> 1.19.41
[master f9ac35b9ccb] python3Packages.botocore: 1.19.40 -> 1.19.41
 1 file changed, 2 insertions(+), 2 deletions(-)
```