### PR TITLE
Add --unstable-version argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,18 @@ Nix-update also can optionally generate a commit message in the form
    [master 53d68a6a5a9] bitcoin-abc: 0.21.1 -> 0.21.2
    1 file changed, 2 insertions(+), 2 deletions(-)
 
+By default, nix-update will attempt to update to the next stable version of a package.
+Alphas, betas, release candidates and similar unstable releases will be ignored.
+This can be affected by changing the parameter `version` from its default value `stable` to `unstable`.
+
+::
+
+  $ nix-update sbt
+  Not updating version, already 1.4.6
+
+  $ nix-update sbt --version=unstable
+  Update 1.4.6 -> 1.5.0-M1 in sbt
+
 TODO
 ----
 

--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -33,6 +33,11 @@ def parse_args() -> Options:
         default="(.*)",
     )
     parser.add_argument(
+        "--unstable-version",
+        action="store_true",
+        help="Include semantic versions with build or pre-release suffixes",
+    )
+    parser.add_argument(
         "--run",
         action="store_true",
         help="provide a shell based on `nix run` with the package in $PATH",
@@ -55,6 +60,7 @@ def parse_args() -> Options:
         attribute=args.attribute,
         test=args.test,
         version_regex=args.version_regex,
+        unstable_version=args.unstable_version,
     )
 
 

--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -33,11 +33,6 @@ def parse_args() -> Options:
         default="(.*)",
     )
     parser.add_argument(
-        "--unstable-version",
-        action="store_true",
-        help="Include semantic versions with build or pre-release suffixes",
-    )
-    parser.add_argument(
         "--run",
         action="store_true",
         help="provide a shell based on `nix run` with the package in $PATH",
@@ -46,7 +41,7 @@ def parse_args() -> Options:
         "--shell", action="store_true", help="provide a shell with the package"
     )
     parser.add_argument(
-        "--version", nargs="?", help="Version to update to", default="auto"
+        "--version", nargs="?", help="Version to update to", default="stable"
     )
     parser.add_argument("attribute", help="Attribute name within the file evaluated")
     args = parser.parse_args()
@@ -60,7 +55,6 @@ def parse_args() -> Options:
         attribute=args.attribute,
         test=args.test,
         version_regex=args.version_regex,
-        unstable_version=args.unstable_version,
     )
 
 

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -12,3 +12,4 @@ class Options:
     run: bool = False
     build: bool = False
     test: bool = False
+    unstable_version: bool = False

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -12,4 +12,3 @@ class Options:
     run: bool = False
     build: bool = False
     test: bool = False
-    unstable_version: bool = False

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 @dataclass
 class Options:
     attribute: str
-    version: str = "auto"
+    version: str = "stable"
     version_regex: str = "(.*)"
     import_path: str = "./."
     commit: bool = False

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -8,6 +8,7 @@ from .eval import Package, eval_attr
 from .options import Options
 from .utils import info, run
 from .version import fetch_latest_version
+from .version.version import VersionPreference
 from .git import old_version_from_git
 
 
@@ -104,9 +105,11 @@ def update_cargo_sha256_hash(opts: Options, filename: str, current_hash: str) ->
 
 
 def update_version(
-    package: Package, version: str, version_regex: str, unstable_version: bool
+    package: Package, version: str, preference: VersionPreference, version_regex: str
 ) -> bool:
-    if version == "auto":
+    if preference == VersionPreference.FIXED:
+        new_version = version
+    else:
         if not package.url:
             if package.urls:
                 package.url = package.urls[0]
@@ -114,9 +117,8 @@ def update_version(
                 raise UpdateError(
                     "Could not find a url in the derivations src attribute"
                 )
-        new_version = fetch_latest_version(package.url, version_regex, unstable_version)
-    else:
-        new_version = version
+        version
+        new_version = fetch_latest_version(package.url, preference, version_regex)
     package.new_version = new_version
     position = package.version_position
     if new_version == package.old_version and position:
@@ -134,9 +136,11 @@ def update(opts: Options) -> Package:
 
     update_hash = True
 
-    if opts.version != "skip":
+    version_preference = VersionPreference.from_str(opts.version)
+
+    if version_preference != VersionPreference.SKIP:
         update_hash = update_version(
-            package, opts.version, opts.version_regex, opts.unstable_version
+            package, opts.version, version_preference, opts.version_regex
         )
 
     if update_hash:

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -103,7 +103,9 @@ def update_cargo_sha256_hash(opts: Options, filename: str, current_hash: str) ->
     replace_hash(filename, current_hash, target_hash)
 
 
-def update_version(package: Package, version: str, version_regex: str) -> bool:
+def update_version(
+    package: Package, version: str, version_regex: str, unstable_version: bool
+) -> bool:
     if version == "auto":
         if not package.url:
             if package.urls:
@@ -112,7 +114,7 @@ def update_version(package: Package, version: str, version_regex: str) -> bool:
                 raise UpdateError(
                     "Could not find a url in the derivations src attribute"
                 )
-        new_version = fetch_latest_version(package.url, version_regex)
+        new_version = fetch_latest_version(package.url, version_regex, unstable_version)
     else:
         new_version = version
     package.new_version = new_version
@@ -133,7 +135,9 @@ def update(opts: Options) -> Package:
     update_hash = True
 
     if opts.version != "skip":
-        update_hash = update_version(package, opts.version, opts.version_regex)
+        update_hash = update_version(
+            package, opts.version, opts.version_regex, opts.unstable_version
+        )
 
     if update_hash:
         update_src_hash(opts, package.filename, package.hash)

--- a/nix_update/utils.py
+++ b/nix_update/utils.py
@@ -1,5 +1,4 @@
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -36,19 +35,3 @@ def run(
     return subprocess.run(
         command, cwd=cwd, check=check, text=True, stdout=stdout, env=env
     )
-
-
-def extract_version(version: str, version_regex: str) -> Optional[str]:
-    pattern = re.compile(version_regex)
-    match = re.match(pattern, version)
-    if match is not None:
-        group = match.group(1)
-        if group is not None:
-            return group
-    return None
-
-
-def version_is_stable(version: str) -> bool:
-    filters = ["rc", "alpha", "beta", "preview", "nightly", "m[0-9]"]
-    filters_in_version = [x for x in filters if re.search(x, version, re.IGNORECASE)]
-    return version is not None and (not any(filters_in_version))

--- a/nix_update/utils.py
+++ b/nix_update/utils.py
@@ -46,3 +46,9 @@ def extract_version(version: str, version_regex: str) -> Optional[str]:
         if group is not None:
             return group
     return None
+
+
+def version_is_stable(version: str) -> bool:
+    filters = ["rc", "alpha", "beta", "preview", "nightly", "m[0-9]"]
+    filters_in_version = [x for x in filters if re.search(x, version, re.IGNORECASE)]
+    return version is not None and (not any(filters_in_version))

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -1,10 +1,13 @@
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult
+from typing import List, Callable, Optional
+import re
 
 from ..errors import VersionError
-from .github import fetch_github_version
-from .gitlab import fetch_gitlab_version
-from .pypi import fetch_pypi_version
-from .rubygems import fetch_rubygem_version
+from .github import fetch_github_versions
+from .gitlab import fetch_gitlab_versions
+from .pypi import fetch_pypi_versions
+from .rubygems import fetch_rubygem_versions
+from .version import VersionPreference, Version
 
 # def find_repology_release(attr) -> str:
 #    resp = urllib.request.urlopen(f"https://repology.org/api/v1/projects/{attr}/")
@@ -15,24 +18,66 @@ from .rubygems import fetch_rubygem_version
 #                return repo["version"]
 #    return None
 
-
-fetchers = [
-    fetch_pypi_version,
-    fetch_github_version,
-    fetch_gitlab_version,
-    fetch_rubygem_version,
+fetchers: List[Callable[[ParseResult], List[Version]]] = [
+    fetch_pypi_versions,
+    fetch_github_versions,
+    fetch_gitlab_versions,
+    fetch_rubygem_versions,
 ]
 
 
+def extract_version(version: str, version_regex: str) -> Optional[str]:
+    pattern = re.compile(version_regex)
+    match = re.match(pattern, version)
+    if match is not None:
+        group = match.group(1)
+        if group is not None:
+            return group
+    return None
+
+
+def is_stable(version: Version, extracted: str) -> bool:
+    if version.prerelease is not None:
+        return version.prerelease
+    pattern = "rc|alpha|beta|preview|nightly|m[0-9]+"
+    return re.search(pattern, extracted, re.IGNORECASE) is None
+
+
 def fetch_latest_version(
-    url_str: str, version_regex: str, unstable_version: bool
+    url_str: str, preference: VersionPreference, version_regex: str
 ) -> str:
     url = urlparse(url_str)
 
+    unstable: List[str] = []
+    filtered: List[str] = []
     for fetcher in fetchers:
-        version = fetcher(url, version_regex, unstable_version)
-        if version is not None:
-            return version
+        versions = fetcher(url)
+        if versions == []:
+            continue
+        final = []
+        for version in versions:
+            extracted = extract_version(version.number, version_regex)
+            if extracted is None:
+                filtered.append(version.number)
+            elif preference == VersionPreference.STABLE and is_stable(
+                version, extracted
+            ):
+                unstable.append(extracted)
+            else:
+                final.append(extracted)
+        if final != []:
+            return final[0]
+
+    if filtered:
+        raise VersionError(
+            "Not version matched the regex. The following versions were found:\n"
+            + "\n".join(filtered)
+        )
+
+    if unstable:
+        raise VersionError(
+            f"Found an unstable version {unstable[0]}, which is being ignored. To update to unstable version, please use '--version=unstable'"
+        )
 
     raise VersionError(
         "Please specify the version. We can only get the latest version from github/gitlab/pypi/rubygems projects right now"

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlparse
 
 from ..errors import VersionError
-from ..utils import extract_version
 from .github import fetch_github_version
 from .gitlab import fetch_gitlab_version
 from .pypi import fetch_pypi_version
@@ -25,15 +24,15 @@ fetchers = [
 ]
 
 
-def fetch_latest_version(url_str: str, version_regex: str) -> str:
+def fetch_latest_version(
+    url_str: str, version_regex: str, unstable_version: bool
+) -> str:
     url = urlparse(url_str)
 
     for fetcher in fetchers:
-        version = fetcher(url, version_regex)
+        version = fetcher(url, version_regex, unstable_version)
         if version is not None:
-            extracted = extract_version(version, version_regex)
-            if extracted is not None:
-                return extracted
+            return version
 
     raise VersionError(
         "Please specify the version. We can only get the latest version from github/gitlab/pypi/rubygems projects right now"

--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -2,28 +2,28 @@ import re
 import urllib.request
 import xml.etree.ElementTree as ET
 from xml.etree.ElementTree import Element
-from typing import Optional
+from typing import List
 from urllib.parse import ParseResult, urlparse
 
+from .version import Version
 from ..errors import VersionError
-from ..utils import extract_version, info, version_is_stable
+from ..utils import info
 
 
-def version_from_entry(entry: Element) -> Optional[str]:
+def version_from_entry(entry: Element) -> Version:
     if entry is None:
         raise VersionError("No release found")
     link = entry.find("{http://www.w3.org/2005/Atom}link")
     assert link is not None
     href = link.attrib["href"]
     url = urlparse(href)
-    return url.path.split("/")[-1]
+    # TODO: set pre-release flag
+    return Version(url.path.split("/")[-1])
 
 
-def fetch_github_version(
-    url: ParseResult, version_regex: str, unstable_version: bool
-) -> Optional[str]:
+def fetch_github_versions(url: ParseResult) -> List[Version]:
     if url.netloc != "github.com":
-        return None
+        return []
     parts = url.path.split("/")
     owner, repo = parts[1], parts[2]
     repo = re.sub(r"\.git$", "", repo)
@@ -33,20 +33,4 @@ def fetch_github_version(
     resp = urllib.request.urlopen(feed_url)
     tree = ET.fromstring(resp.read())
     releases = tree.findall(".//{http://www.w3.org/2005/Atom}entry")
-    entries = [version_from_entry(x) for x in releases]
-    extracted = [extract_version(x, version_regex) for x in entries if x is not None]
-    filtered = [
-        x
-        for x in extracted
-        if x is not None and (unstable_version or version_is_stable(x))
-    ]
-
-    if filtered[0] is not None:
-        return filtered[0]
-
-    if extracted[0] is not None and not unstable_version:
-        print(
-            f"Found an unstable version {extracted[0]}, which is being ignored. To update to unstable version, please use '--unstable-version'"
-        )
-
-    return None
+    return [version_from_entry(x) for x in releases]

--- a/nix_update/version/pypi.py
+++ b/nix_update/version/pypi.py
@@ -3,10 +3,12 @@ import urllib.request
 from typing import Optional
 from urllib.parse import ParseResult
 
-from ..utils import extract_version, info
+from ..utils import extract_version, info, version_is_stable
 
 
-def fetch_pypi_version(url: ParseResult, version_regex: str) -> Optional[str]:
+def fetch_pypi_version(
+    url: ParseResult, version_regex: str, unstable_version: bool
+) -> Optional[str]:
     if url.netloc != "pypi":
         return None
     parts = url.path.split("/")
@@ -17,4 +19,8 @@ def fetch_pypi_version(url: ParseResult, version_regex: str) -> Optional[str]:
     data = json.loads(resp.read())
     version = data["info"]["version"]
     assert isinstance(version, str)
-    return extract_version(version, version_regex)
+    extracted = extract_version(version, version_regex)
+    if extracted is not None and (unstable_version or version_is_stable(extracted)):
+        return extracted
+
+    return None

--- a/nix_update/version/pypi.py
+++ b/nix_update/version/pypi.py
@@ -1,16 +1,15 @@
 import json
 import urllib.request
-from typing import Optional
+from typing import List
 from urllib.parse import ParseResult
 
-from ..utils import extract_version, info, version_is_stable
+from .version import Version
+from ..utils import info
 
 
-def fetch_pypi_version(
-    url: ParseResult, version_regex: str, unstable_version: bool
-) -> Optional[str]:
+def fetch_pypi_versions(url: ParseResult) -> List[Version]:
     if url.netloc != "pypi":
-        return None
+        return []
     parts = url.path.split("/")
     package = parts[2]
     pypi_url = f"https://pypi.org/pypi/{package}/json"
@@ -19,8 +18,5 @@ def fetch_pypi_version(
     data = json.loads(resp.read())
     version = data["info"]["version"]
     assert isinstance(version, str)
-    extracted = extract_version(version, version_regex)
-    if extracted is not None and (unstable_version or version_is_stable(extracted)):
-        return extracted
-
-    return None
+    # TODO look at info->releases instead
+    return [Version(version)]

--- a/nix_update/version/rubygems.py
+++ b/nix_update/version/rubygems.py
@@ -1,35 +1,32 @@
 import urllib.request
-from typing import Optional
+from typing import List
 from urllib.parse import ParseResult
 import json
 
+from .version import Version
 from ..errors import VersionError
-from ..utils import extract_version, info, version_is_stable
+
+from ..utils import info
 
 
-def fetch_rubygem_version(
-    url: ParseResult, version_regex: str, unstable_version: bool
-) -> Optional[str]:
+def fetch_rubygem_versions(url: ParseResult) -> List[Version]:
     if url.netloc != "rubygems.org":
-        return None
+        return []
     parts = url.path.split("/")
     gem = parts[-1]
     gem_name, rest = gem.rsplit("-")
     versions_url = f"https://rubygems.org/api/v1/versions/{gem_name}.json"
     info(f"fetch {versions_url}")
     resp = urllib.request.urlopen(versions_url)
-    versions = json.load(resp)
-    if len(versions) == 0:
+    json_versions = json.load(resp)
+    if len(json_versions) == 0:
         raise VersionError("No versions found")
-    for version in versions:
-        if not version["prerelease"]:
-            number = version["number"]
-            assert isinstance(number, str)
-            extracted = extract_version(number, version_regex)
-            if extracted is not None and (
-                unstable_version or version_is_stable(extracted)
-            ):
-                return extracted
-    number = versions[0]["number"]
-    assert isinstance(number, str)
-    return extract_version(number, version_regex)
+
+    versions: List[Version] = []
+    for version in json_versions:
+        number = version["number"]
+        assert isinstance(number, str)
+        prerelease = version["prerelease"]
+        assert isinstance(prerelease, bool)
+        version.append(Version(number, prerelease=prerelease))
+    return versions

--- a/nix_update/version/rubygems.py
+++ b/nix_update/version/rubygems.py
@@ -4,10 +4,12 @@ from urllib.parse import ParseResult
 import json
 
 from ..errors import VersionError
-from ..utils import extract_version, info
+from ..utils import extract_version, info, version_is_stable
 
 
-def fetch_rubygem_version(url: ParseResult, version_regex: str) -> Optional[str]:
+def fetch_rubygem_version(
+    url: ParseResult, version_regex: str, unstable_version: bool
+) -> Optional[str]:
     if url.netloc != "rubygems.org":
         return None
     parts = url.path.split("/")
@@ -24,7 +26,9 @@ def fetch_rubygem_version(url: ParseResult, version_regex: str) -> Optional[str]
             number = version["number"]
             assert isinstance(number, str)
             extracted = extract_version(number, version_regex)
-            if extracted is not None:
+            if extracted is not None and (
+                unstable_version or version_is_stable(extracted)
+            ):
                 return extracted
     number = versions[0]["number"]
     assert isinstance(number, str)

--- a/nix_update/version/version.py
+++ b/nix_update/version/version.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Optional
+
+
+@dataclass
+class Version:
+    number: str
+    prerelease: Optional[bool] = False
+
+
+class VersionPreference(Enum):
+    STABLE = auto()
+    UNSTABLE = auto()
+    FIXED = auto()
+    SKIP = auto()
+
+    @staticmethod
+    def from_str(version: str) -> "VersionPreference":
+        # auto is deprecated
+        if version == "auto" or version == "stable":
+            return VersionPreference.STABLE
+        elif version == "unstable":
+            return VersionPreference.UNSTABLE
+        elif version == "skip":
+            return VersionPreference.SKIP
+        return VersionPreference.FIXED


### PR DESCRIPTION
Enabling this flag will include all versions
containing '-' and '+' from being considered valid.
As per SemVer, these are the separators for unstable
versions (i.e. "-RC2", "+abcdef" suffixes).