### PR TITLE
Fix --format

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -175,7 +175,7 @@ def nixpkgs_review() -> None:
     run(cmd, check=True)
 
 
-def nixpkgs_fmt(git_dir: Optional[str], package: Package) -> None:
+def nixpkgs_fmt(package: Package, git_dir: Optional[str]) -> None:
     cmd = ["nixpkgs-fmt", package.filename]
     run(cmd, check=True)
     if git_dir is not None:
@@ -218,7 +218,7 @@ def main() -> None:
         nixpkgs_review()
 
     if options.format:
-        nixpkgs_fmt(git_dir, package)
+        nixpkgs_fmt(package, git_dir)
 
     if options.commit:
         assert git_dir is not None

--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -175,9 +175,11 @@ def nixpkgs_review() -> None:
     run(cmd, check=True)
 
 
-def nixpkgs_fmt(package: Package) -> None:
+def nixpkgs_fmt(git_dir: Optional[str], package: Package) -> None:
     cmd = ["nixpkgs-fmt", package.filename]
     run(cmd, check=True)
+    if git_dir is not None:
+        run(["git", "-C", git_dir, "add", package.filename], stdout=None)
 
 
 def main() -> None:
@@ -216,7 +218,7 @@ def main() -> None:
         nixpkgs_review()
 
     if options.format:
-        nixpkgs_fmt(package)
+        nixpkgs_fmt(git_dir, package)
 
     if options.commit:
         assert git_dir is not None


### PR DESCRIPTION
If used in combination with --commit, the changes
were previously not staged and hence left uncommitted
