### PR TITLE
update unstable packages from git to latest branch

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -89,7 +89,7 @@ def git_has_diff(git_dir: str, package: Package) -> bool:
 
 
 def format_commit_message(package: Package) -> str:
-    new_version = package.new_version
+    new_version = getattr(package.new_version, "number", None)
     if (
         new_version
         and package.old_version != new_version
@@ -102,7 +102,7 @@ def format_commit_message(package: Package) -> str:
 def git_commit(git_dir: str, package: Package) -> None:
     msg = format_commit_message(package)
     new_version = package.new_version
-    if new_version and package.old_version != new_version:
+    if new_version and package.old_version != new_version.number:
         run(
             ["git", "-C", git_dir, "commit", "--verbose", "--message", msg], stdout=None
         )

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -59,7 +59,7 @@ def eval_expression(import_path: str, attr: str) -> str:
         builtins.unsafeGetAttrPos "src" pkg;
     in {{
       name = pkg.name;
-      old_version = (builtins.parseDrvName pkg.name).version;
+      old_version = pkg.version or (builtins.parseDrvName pkg.name).version;
       inherit raw_version_position;
       filename = position.file;
       line = position.line;

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -65,7 +65,7 @@ def eval_expression(import_path: str, attr: str) -> str:
       line = position.line;
       urls = pkg.src.urls or null;
       url = pkg.src.url or null;
-      rev = pkg.src.url.rev or null;
+      rev = pkg.src.rev or null;
       hash = pkg.src.outputHash or null;
       mod_sha256 = pkg.modSha256 or null;
       vendor_sha256 = pkg.vendorSha256 or null;

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Dict, Any
 
 from .errors import UpdateError
 from .options import Options
-from .version.version import VersionPreference
+from .version.version import Version, VersionPreference
 from .utils import run
 
 
@@ -33,7 +33,7 @@ class Package:
 
     raw_version_position: InitVar[Optional[Dict[str, Any]]]
 
-    new_version: Optional[str] = None
+    new_version: Optional[Version] = None
     version_position: Optional[Position] = field(init=False)
 
     def __post_init__(self, raw_version_position: Optional[Dict[str, Any]]) -> None:

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -125,7 +125,17 @@ def update_version(
                     "Could not find a url in the derivations src attribute"
                 )
         version
-        new_version = fetch_latest_version(package.url, preference, version_regex)
+        if preference != VersionPreference.BRANCH:
+            branch = None
+        elif version == "branch":
+            # fallback
+            branch = "master"
+        else:
+            assert version.startswith("branch=")
+            branch = version[7:]
+        new_version = fetch_latest_version(
+            package.url, preference, version_regex, branch
+        )
     package.new_version = new_version
     position = package.version_position
     if new_version.number == package.old_version and position:

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -9,7 +9,6 @@ from .git import old_version_from_git
 from .options import Options
 from .utils import info, run
 from .version import fetch_latest_version
-from .git import old_version_from_git
 from .version.version import Version, VersionPreference
 
 

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -129,7 +129,7 @@ def update_version(
             branch = None
         elif version == "branch":
             # fallback
-            branch = "master"
+            branch = "HEAD"
         else:
             assert version.startswith("branch=")
             branch = version[7:]

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -5,7 +5,7 @@ import re
 
 from ..errors import VersionError
 from .github import fetch_github_versions, fetch_github_snapshots
-from .gitlab import fetch_gitlab_versions
+from .gitlab import fetch_gitlab_versions, fetch_gitlab_snapshots
 from .pypi import fetch_pypi_versions
 from .rubygems import fetch_rubygem_versions
 from .savannah import fetch_savannah_versions
@@ -32,6 +32,7 @@ fetchers: List[Callable[[ParseResult], List[Version]]] = [
 
 branch_snapshots_fetchers: List[Callable[[ParseResult, str], List[Version]]] = [
     fetch_github_snapshots,
+    fetch_gitlab_snapshots,
 ]
 
 

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -30,13 +30,13 @@ fetchers: List[Callable[[ParseResult], List[Version]]] = [
 ]
 
 
-def extract_version(version: str, version_regex: str) -> Optional[str]:
+def extract_version(version: Version, version_regex: str) -> Optional[Version]:
     pattern = re.compile(version_regex)
-    match = re.match(pattern, version)
+    match = re.match(pattern, version.number)
     if match is not None:
         group = match.group(1)
         if group is not None:
-            return group
+            return Version(group, prerelease=version.prerelease, rev=version.rev)
     return None
 
 
@@ -60,13 +60,13 @@ def fetch_latest_version(
             continue
         final = []
         for version in versions:
-            extracted = extract_version(version.number, version_regex)
+            extracted = extract_version(version, version_regex)
             if extracted is None:
                 filtered.append(version.number)
             elif preference == VersionPreference.STABLE and is_unstable(
-                version, extracted
+                version, extracted.number
             ):
-                unstable.append(extracted)
+                unstable.append(extracted.number)
             else:
                 final.append(extracted)
         if final != []:

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -5,8 +5,8 @@ from urllib.parse import ParseResult, urlparse
 
 from ..errors import VersionError
 from .crate import fetch_crate_versions
-from .github import fetch_github_versions, fetch_github_snapshots
-from .gitlab import fetch_gitlab_versions, fetch_gitlab_snapshots
+from .github import fetch_github_snapshots, fetch_github_versions
+from .gitlab import fetch_gitlab_snapshots, fetch_gitlab_versions
 from .pypi import fetch_pypi_versions
 from .rubygems import fetch_rubygem_versions
 from .savannah import fetch_savannah_versions

--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -34,3 +34,28 @@ def fetch_github_versions(url: ParseResult) -> List[Version]:
     tree = ET.fromstring(resp.read())
     releases = tree.findall(".//{http://www.w3.org/2005/Atom}entry")
     return [version_from_entry(x) for x in releases]
+
+
+def fetch_github_snapshots(url: ParseResult, branch: str) -> List[Version]:
+    if url.netloc != "github.com":
+        return []
+    parts = url.path.split("/")
+    owner, repo = parts[1], parts[2]
+    repo = re.sub(r"\.git$", "", repo)
+    feed_url = f"https://github.com/{owner}/{repo}/commits/{branch}.atom"
+    info(f"fetch {feed_url}")
+    resp = urllib.request.urlopen(feed_url)
+    tree = ET.fromstring(resp.read())
+    commits = tree.findall(".//{http://www.w3.org/2005/Atom}entry")
+
+    for entry in commits:
+        link = entry.find("{http://www.w3.org/2005/Atom}link")
+        updated = entry.find("{http://www.w3.org/2005/Atom}updated")
+        if link is None or updated is None or updated.text is None:
+            continue
+        url = urlparse(link.attrib["href"])
+        commit = url.path.rsplit("/", maxsplit=1)[-1]
+        date = updated.text.split("T", maxsplit=1)[0]
+        return [Version(f"unstable-{date}", rev=commit)]
+
+    return []

--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -51,8 +51,9 @@ def fetch_github_snapshots(url: ParseResult, branch: str) -> List[Version]:
     for entry in commits:
         link = entry.find("{http://www.w3.org/2005/Atom}link")
         updated = entry.find("{http://www.w3.org/2005/Atom}updated")
-        if link is None or updated is None or updated.text is None:
-            continue
+        assert (
+            link is not None and updated is not None and updated.text is not None
+        ), "cannot parse ATOM feed"
         url = urlparse(link.attrib["href"])
         commit = url.path.rsplit("/", maxsplit=1)[-1]
         date = updated.text.split("T", maxsplit=1)[0]

--- a/nix_update/version/gitlab.py
+++ b/nix_update/version/gitlab.py
@@ -1,8 +1,9 @@
 import json
 import re
 import urllib.request
+from datetime import datetime
 from typing import List
-from urllib.parse import ParseResult
+from urllib.parse import ParseResult, quote_plus
 
 from .version import Version
 from ..errors import VersionError
@@ -39,3 +40,20 @@ def fetch_gitlab_versions(url: ParseResult) -> List[Version]:
     if releases == []:
         return tags
     return releases
+
+
+def fetch_gitlab_snapshots(url: ParseResult, branch: str) -> List[Version]:
+    match = GITLAB_API.match(url.geturl())
+    if not match:
+        return []
+    domain = match.group("domain")
+    project_id = match.group("project_id")
+    gitlab_url = f"https://{domain}/api/v4/projects/{project_id}/repository/commits?ref_name={quote_plus(branch)}"
+    info(f"fetch {gitlab_url}")
+    resp = urllib.request.urlopen(gitlab_url)
+    commits = json.load(resp)
+    for commit in commits:
+        date = datetime.strptime(commit["committed_date"], "%Y-%m-%dT%H:%M:%S.000%z")
+        date -= date.utcoffset()  # type: ignore[operator]
+        return [Version(date.strftime("unstable-%Y-%m-%d"), rev=commit["id"])]
+    return []

--- a/nix_update/version/version.py
+++ b/nix_update/version/version.py
@@ -8,6 +8,7 @@ from typing import Optional
 class Version:
     number: str
     prerelease: Optional[bool] = None
+    rev: Optional[str] = None
 
 
 class VersionPreference(Enum):

--- a/nix_update/version/version.py
+++ b/nix_update/version/version.py
@@ -16,6 +16,7 @@ class VersionPreference(Enum):
     UNSTABLE = auto()
     FIXED = auto()
     SKIP = auto()
+    BRANCH = auto()
 
     @staticmethod
     def from_str(version: str) -> "VersionPreference":
@@ -26,4 +27,6 @@ class VersionPreference(Enum):
             return VersionPreference.UNSTABLE
         elif version == "skip":
             return VersionPreference.SKIP
+        elif version == "branch" or version.startswith("branch="):
+            return VersionPreference.BRANCH
         return VersionPreference.FIXED

--- a/tests/test_branch.atom
+++ b/tests/test_branch.atom
@@ -1,0 +1,385 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="en-US">
+  <id>tag:github.com,2008:/Mic92/nix-update/commits/master</id>
+  <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commits/master"/>
+  <link type="application/atom+xml" rel="self" href="https://github.com/Mic92/nix-update/commits/master.atom"/>
+  <title>Recent Commits to nix-update:master</title>
+  <updated>2021-12-13T14:02:42Z</updated>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/79dcae59a9d16ec003bda4e232319db2fb83e252</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/79dcae59a9d16ec003bda4e232319db2fb83e252"/>
+    <title>
+        Merge pull request #74 from Mic92/mypy-fix
+    </title>
+    <updated>2021-12-13T14:02:42Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #74 from Mic92/mypy-fix
+
+fix mypy&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/8e88950e6cab1f2b5e7be759b14e21cef7e6615d</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/8e88950e6cab1f2b5e7be759b14e21cef7e6615d"/>
+    <title>
+        fix mypy
+    </title>
+    <updated>2021-12-13T14:00:12Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;fix mypy&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4692eb3a5cd27cc0cbce2cafe013271b62c8ec03</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/4692eb3a5cd27cc0cbce2cafe013271b62c8ec03"/>
+    <title>
+        Merge pull request #72 from Mic92/dependabot/github_actions/cachix/in…
+    </title>
+    <updated>2021-11-22T07:01:11Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #72 from Mic92/dependabot/github_actions/cachix/install-nix-action-16
+
+Bump cachix/install-nix-action from 15 to 16&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/4efc9f1f37f555b326cfb722572506a099c71e53</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/4efc9f1f37f555b326cfb722572506a099c71e53"/>
+    <title>
+        Bump cachix/install-nix-action from 15 to 16
+    </title>
+    <updated>2021-11-22T06:01:34Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/in/29110?s=30&amp;v=4"/>
+    <author>
+      <name>dependabot</name>
+      <uri>https://github.com/dependabot</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Bump cachix/install-nix-action from 15 to 16
+
+Bumps [cachix/install-nix-action](https://github.com/cachix/install-nix-action) from 15 to 16.
+- [Release notes](https://github.com/cachix/install-nix-action/releases)
+- [Commits](https://github.com/cachix/install-nix-action/compare/v15...v16)
+
+---
+updated-dependencies:
+- dependency-name: cachix/install-nix-action
+  dependency-type: direct:production
+  update-type: version-update:semver-major
+...
+
+Signed-off-by: dependabot[bot] &amp;lt;support@github.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/b668fe6ea0b3d8464a1ede78d7306f309a6fb7f6</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/b668fe6ea0b3d8464a1ede78d7306f309a6fb7f6"/>
+    <title>
+        Merge pull request #70 from Mic92/ci
+    </title>
+    <updated>2021-11-15T07:45:54Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #70 from Mic92/ci
+
+drop install_url&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/079aac11c75d03e534e948a5f8cfa2bb6f5ffd52</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/079aac11c75d03e534e948a5f8cfa2bb6f5ffd52"/>
+    <title>
+        drop install_url
+    </title>
+    <updated>2021-11-15T07:40:32Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;drop install_url&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/a494f951a76c77c796dd739ce18717a989a9ec2c</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/a494f951a76c77c796dd739ce18717a989a9ec2c"/>
+    <title>
+        Merge pull request #69 from Mic92/dependabot/github_actions/cachix/in…
+    </title>
+    <updated>2021-11-15T07:39:58Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #69 from Mic92/dependabot/github_actions/cachix/install-nix-action-15
+
+Bump cachix/install-nix-action from 14 to 15&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/543030454c3e65e10b4ce6dc18f2f0f3b65c5484</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/543030454c3e65e10b4ce6dc18f2f0f3b65c5484"/>
+    <title>
+        Bump cachix/install-nix-action from 14 to 15
+    </title>
+    <updated>2021-11-15T06:00:49Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/in/29110?s=30&amp;v=4"/>
+    <author>
+      <name>dependabot</name>
+      <uri>https://github.com/dependabot</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Bump cachix/install-nix-action from 14 to 15
+
+Bumps [cachix/install-nix-action](https://github.com/cachix/install-nix-action) from 14 to 15.
+- [Release notes](https://github.com/cachix/install-nix-action/releases)
+- [Commits](https://github.com/cachix/install-nix-action/compare/v14...v15)
+
+---
+updated-dependencies:
+- dependency-name: cachix/install-nix-action
+  dependency-type: direct:production
+  update-type: version-update:semver-major
+...
+
+Signed-off-by: dependabot[bot] &amp;lt;support@github.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/52582817e8c6474c23b2855aa4bed2b53e708741</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/52582817e8c6474c23b2855aa4bed2b53e708741"/>
+    <title>
+        Merge pull request #67 from Mic92/dependabot/github_actions/cachix/in…
+    </title>
+    <updated>2021-09-13T11:29:28Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #67 from Mic92/dependabot/github_actions/cachix/install-nix-action-14
+
+Bump cachix/install-nix-action from 13 to 14&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/72527c376744fb03f9558b7bb7b4195b082268d8</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/72527c376744fb03f9558b7bb7b4195b082268d8"/>
+    <title>
+        Bump cachix/install-nix-action from 13 to 14
+    </title>
+    <updated>2021-09-13T06:00:54Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/in/29110?s=30&amp;v=4"/>
+    <author>
+      <name>dependabot</name>
+      <uri>https://github.com/dependabot</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Bump cachix/install-nix-action from 13 to 14
+
+Bumps [cachix/install-nix-action](https://github.com/cachix/install-nix-action) from 13 to 14.
+- [Release notes](https://github.com/cachix/install-nix-action/releases)
+- [Commits](https://github.com/cachix/install-nix-action/compare/v13...v14)
+
+---
+updated-dependencies:
+- dependency-name: cachix/install-nix-action
+  dependency-type: direct:production
+  update-type: version-update:semver-major
+...
+
+Signed-off-by: dependabot[bot] &amp;lt;support@github.com&amp;gt;&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/70bdf762e5be36ddea70234daa0d476fea0498ff</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/70bdf762e5be36ddea70234daa0d476fea0498ff"/>
+    <title>
+        README: migrate from restructured text
+    </title>
+    <updated>2021-09-02T04:57:00Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;README: migrate from restructured text&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/b167cc623191bc8bb1afbc7f3ab5ac0a039f70dd</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/b167cc623191bc8bb1afbc7f3ab5ac0a039f70dd"/>
+    <title>
+        Merge pull request #65 from Mic92/cargo-sha256
+    </title>
+    <updated>2021-08-26T13:48:04Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #65 from Mic92/cargo-sha256
+
+allow to upload cargo checksum when source is local&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/2f498d50d7d70217557804907244062cb35a9e6b</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/2f498d50d7d70217557804907244062cb35a9e6b"/>
+    <title>
+        don&#39;t require valid version if --version=skip
+    </title>
+    <updated>2021-08-26T13:45:05Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;don&amp;#39;t require valid version if --version=skip&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/008e69ed04e4ff2bc962bb2b5c1e04bb3c725cb5</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/008e69ed04e4ff2bc962bb2b5c1e04bb3c725cb5"/>
+    <title>
+        allow to upload cargo checksum when source is local
+    </title>
+    <updated>2021-08-26T11:08:18Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;allow to upload cargo checksum when source is local&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/474e358eeab1dbeabddd0a16ecf647695e90f43b</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/474e358eeab1dbeabddd0a16ecf647695e90f43b"/>
+    <title>
+        Merge pull request #63 from Mic92/nixos-tests
+    </title>
+    <updated>2021-08-21T12:58:05Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #63 from Mic92/nixos-tests
+
+fix evaluation on macos for pkgs with tests&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/bec42b219b9d4dfe6cef6abd5e71b4753996e00a</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/bec42b219b9d4dfe6cef6abd5e71b4753996e00a"/>
+    <title>
+        fix evaluation on macos for pkgs with tests
+    </title>
+    <updated>2021-08-21T08:33:02Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;fix evaluation on macos for pkgs with tests
+
+fixes https://github.com/Mic92/nix-update/issues/62&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/3c77336eecf836c34b866271a58f74f1dc2a524d</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/3c77336eecf836c34b866271a58f74f1dc2a524d"/>
+    <title>
+        Merge pull request #60 from SuperSandro2000/sourcehut
+    </title>
+    <updated>2021-08-15T22:27:59Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/96200?s=30&amp;u=9ed15c85825694d00e996d605d728179b830c4fa&amp;v=4"/>
+    <author>
+      <name>Mic92</name>
+      <uri>https://github.com/Mic92</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Merge pull request #60 from SuperSandro2000/sourcehut
+
+Add sourcehut support, minor cleanups&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/3ece737ad749ca480072921f145ca1b7d9da5498</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/3ece737ad749ca480072921f145ca1b7d9da5498"/>
+    <title>
+        Fix tests
+    </title>
+    <updated>2021-08-15T22:23:35Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/7258858?s=30&amp;u=c524720e2844ffa8a2aa67944fde5af54031e06d&amp;v=4"/>
+    <author>
+      <name>SuperSandro2000</name>
+      <uri>https://github.com/SuperSandro2000</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Fix tests&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/45fef9987cc850c36a8ed2bca0177f44b267f095</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/45fef9987cc850c36a8ed2bca0177f44b267f095"/>
+    <title>
+        Add lorri files to run tests
+    </title>
+    <updated>2021-08-15T22:23:35Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/7258858?s=30&amp;u=c524720e2844ffa8a2aa67944fde5af54031e06d&amp;v=4"/>
+    <author>
+      <name>SuperSandro2000</name>
+      <uri>https://github.com/SuperSandro2000</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Add lorri files to run tests&lt;/pre&gt;
+    </content>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Grit::Commit/6ae3eb12864a4d5945f21a870ca4c97208a3a325</id>
+    <link type="text/html" rel="alternate" href="https://github.com/Mic92/nix-update/commit/6ae3eb12864a4d5945f21a870ca4c97208a3a325"/>
+    <title>
+        Remove unused import
+    </title>
+    <updated>2021-08-15T15:09:09Z</updated>
+    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/7258858?s=30&amp;u=c524720e2844ffa8a2aa67944fde5af54031e06d&amp;v=4"/>
+    <author>
+      <name>SuperSandro2000</name>
+      <uri>https://github.com/SuperSandro2000</uri>
+    </author>
+    <content type="html">
+      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;Remove unused import&lt;/pre&gt;
+    </content>
+  </entry>
+</feed>

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -3,10 +3,10 @@ import unittest.mock
 from pathlib import Path
 from typing import BinaryIO
 
+import conftest
+
 from nix_update.version import fetch_latest_version
 from nix_update.version.version import VersionPreference
-
-import conftest
 
 TEST_ROOT = Path(__file__).parent.resolve()
 

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import unittest.mock
+from pathlib import Path
+from typing import BinaryIO
+
+from nix_update.version import fetch_latest_version
+from nix_update.version.version import VersionPreference
+
+import conftest
+
+TEST_ROOT = Path(__file__).parent.resolve()
+
+
+def fake_urlopen(url: str) -> BinaryIO:
+    return open(TEST_ROOT.joinpath("test_branch.atom"), "rb")
+
+
+def test_branch(helpers: conftest.Helpers) -> None:
+    with unittest.mock.patch("urllib.request.urlopen", fake_urlopen):
+        assert (
+            fetch_latest_version(
+                "https://github.com/Mic92/nix-update",
+                VersionPreference.BRANCH,
+                "(.*)",
+                "master",
+            ).number
+            == "unstable-2021-12-13"
+        )


### PR DESCRIPTION
This adds VersionPreference.BRANCH. By passing `--version=branch[=<name>]` the commits of branch `<name>` (`master` if ommitted) are fetched and versions `unstable-YYYY-MM-DD` are generated containing all commits up to and including this date.

This also uses Version objects instead of version number strings to allow us to pass an additional `rev` to `replace_version`.

I am not sure about the tweaks to eval.py but using nix's version parsing creates version like `unstable-unstable-YYYY-MM-DD` and `pkgs.src.url.rev` seemed like a mistake to me.