### PR TITLE
add support for cargoDeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ designed to work with nixpkgs but also other package sets.
     -   gitlab.com or other instances that uses fetchFromGitLab
     -   pypi
     -   rubygems.org
--   update buildRustPackage's cargoHash/cargoSha256
+-   update buildRustPackage's cargoHash/cargoSha256 and cargoSetupHook's cargoDeps
 -   update buildGoModule's vendorHash/vendorSha256
 -   update buildNpmPackage's npmDepsHash
 -   build and run the resulting package (see `--build`,

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -71,7 +71,7 @@ def eval_expression(import_path: str, attr: str) -> str:
       hash = pkg.src.outputHash or null;
       vendor_hash = pkg.vendorHash or null;
       vendor_sha256 = pkg.vendorSha256 or null;
-      cargo_deps = pkg.cargoHash or pkg.cargoSha256 or null;
+      cargo_deps = (pkg.cargoDeps or null).outputHash or null;
       npm_deps = pkg.npmDepsHash or null;
       tests = builtins.attrNames (pkg.passthru.tests or {{}});
       changelog = pkg.meta.changelog or null;


### PR DESCRIPTION
`cargoDeps` is used with [cargoSetupHook](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/rust/hooks/cargo-setup-hook.sh) and usually [fetchCargoTarball](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/rust/fetch-cargo-tarball/default.nix) to specify dependencies for cargo packages

`cargoHash` and `cargoSha256` would still work since they are implemented in `buildRustPackage` using `cargoDeps = fetchCargTarball {...}`

example: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/spot/default.nix