### PR TITLE
inherit stdout and stderr when appropriate

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -181,11 +181,7 @@ def nix_build(options: Options) -> None:
         options.import_path,
         options.attribute,
     ]
-    run(
-        cmd,
-        stdout=None,
-        check=True,
-    )
+    run(cmd, stdout=None)
 
 
 def nix_test(package: Package) -> None:
@@ -197,7 +193,7 @@ def nix_test(package: Package) -> None:
         tests.append("-A")
         tests.append(f"{package.attribute}.tests.{t}")
     cmd = ["nix-build"] + tests
-    run(cmd, check=True)
+    run(cmd, stdout=None)
 
 
 def nixpkgs_review() -> None:
@@ -205,12 +201,12 @@ def nixpkgs_review() -> None:
         "nixpkgs-review",
         "wip",
     ]
-    run(cmd, check=True)
+    run(cmd, stdout=None)
 
 
 def nixpkgs_fmt(package: Package, git_dir: Optional[str]) -> None:
     cmd = ["nixpkgs-fmt", package.filename]
-    run(cmd, check=True)
+    run(cmd, stdout=None)
     if git_dir is not None:
         run(["git", "-C", git_dir, "add", package.filename], stdout=None)
 

--- a/nix_update/git.py
+++ b/nix_update/git.py
@@ -1,6 +1,7 @@
 import re
-import subprocess
 from typing import Optional
+
+from .utils import run
 
 
 def old_version_from_diff(
@@ -37,10 +38,8 @@ def old_version_from_diff(
 def old_version_from_git(
     filename: str, linenumber: int, new_version: str
 ) -> Optional[str]:
-    proc = subprocess.run(
+    proc = run(
         ["git", "diff", "--color=never", "--word-diff=porcelain", "--", filename],
-        text=True,
-        stdout=subprocess.PIPE,
     )
     assert proc.stdout is not None
     if len(proc.stdout) == 0:

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -54,7 +54,7 @@ def to_sri(hashstr: str) -> str:
         "to-sri",
         f"{prefix}{hashstr}",
     ]
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, check=True, text=True)
+    proc = run(cmd)
     return proc.stdout.rstrip("\n")
 
 

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -81,6 +81,7 @@ def nix_prefetch(expr: str) -> str:
                 f'let src = {expr}; in (src.overrideAttrs or (f: src // f src)) (_: {{ outputHash = ""; outputHashAlgo = "sha256"; }})',
             ],
             extra_env=extra_env,
+            stderr=subprocess.PIPE,
             check=False,
         )
         stderr = res.stderr.strip()

--- a/nix_update/utils.py
+++ b/nix_update/utils.py
@@ -26,7 +26,7 @@ def run(
     command: List[str],
     cwd: Optional[Union[Path, str]] = None,
     stdout: Union[None, int, IO[Any]] = subprocess.PIPE,
-    stderr: Union[None, int, IO[Any]] = subprocess.PIPE,
+    stderr: Union[None, int, IO[Any]] = None,
     check: bool = True,
     extra_env: Dict[str, str] = {},
 ) -> "subprocess.CompletedProcess[str]":


### PR DESCRIPTION
this will give users more feedback, e.g. we will have a status bar from nix during `--build`

also changes the default for `run` to inherit stderr because most `run` calls don't need to capture stderr