### PR TITLE
Add diff feature

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -103,6 +103,8 @@ def format_commit_message(package: Package) -> str:
     ):
         new_version = new_version[1:]
     msg = f"{package.attribute}: {package.old_version} -> {new_version}"
+    if package.diff_url:
+        msg += f"\n\nDiff: {package.diff_url}"
     if package.changelog:
         msg += f"\n\nChangelog: {package.changelog}"
     return msg

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Dict, List, Optional
+from urllib.parse import ParseResult, urlparse
 
 from .errors import UpdateError
 from .options import Options
@@ -24,6 +25,7 @@ class Package:
     line: int
     urls: Optional[List[str]]
     url: Optional[str]
+    src_homepage: Optional[str]
     changelog: Optional[str]
     rev: str
     hash: Optional[str]
@@ -35,10 +37,15 @@ class Package:
 
     raw_version_position: InitVar[Optional[Dict[str, Any]]]
 
+    parsed_url: Optional[ParseResult] = None
     new_version: Optional[Version] = None
     version_position: Optional[Position] = field(init=False)
+    diff_url: Optional[str] = None
 
     def __post_init__(self, raw_version_position: Optional[Dict[str, Any]]) -> None:
+        url = self.url or (self.urls[0] if self.urls else None)
+        if url:
+            self.parsed_url = urlparse(url)
         if raw_version_position is None:
             self.version_position = None
         else:
@@ -74,6 +81,7 @@ def eval_expression(import_path: str, attr: str) -> str:
       cargo_deps = (pkg.cargoDeps or null).outputHash or null;
       npm_deps = (pkg.npmDeps or null).outputHash or null;
       tests = builtins.attrNames (pkg.passthru.tests or {{}});
+      src_homepage = pkg.src.meta.homepage or null;
       changelog = pkg.meta.changelog or null;
     }})"""
 

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -1,7 +1,7 @@
 import re
 from functools import partial
 from typing import Callable, List, Optional
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult
 
 from ..errors import VersionError
 from .crate import fetch_crate_versions
@@ -56,13 +56,11 @@ def is_unstable(version: Version, extracted: str) -> bool:
 
 
 def fetch_latest_version(
-    url_str: str,
+    url: ParseResult,
     preference: VersionPreference,
     version_regex: str,
     branch: Optional[str] = None,
 ) -> Version:
-    url = urlparse(url_str)
-
     unstable: List[str] = []
     filtered: List[str] = []
     used_fetchers = fetchers

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -2,6 +2,7 @@
 import unittest.mock
 from pathlib import Path
 from typing import BinaryIO
+from urllib.parse import urlparse
 
 import conftest
 
@@ -19,7 +20,7 @@ def test_branch(helpers: conftest.Helpers) -> None:
     with unittest.mock.patch("urllib.request.urlopen", fake_urlopen):
         assert (
             fetch_latest_version(
-                "https://github.com/Mic92/nix-update",
+                urlparse("https://github.com/Mic92/nix-update"),
                 VersionPreference.BRANCH,
                 "(.*)",
                 "master",

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,36 @@
+import subprocess
+
+import conftest
+
+from nix_update import main
+
+
+def test_main(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(["--file", str(path), "--commit", "github"])
+        version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "github.version",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert version >= "8.5.2"
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(commit)
+        assert version in commit
+        assert "github" in commit
+        assert "https://github.com/sharkdp/fd/compare/v8.0.0...v" in commit

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,0 +1,38 @@
+import subprocess
+
+import conftest
+
+from nix_update import main
+
+
+def test_main(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(["--file", str(path), "--commit", "gitlab"])
+        version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "gitlab.version",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert version >= "0.22.0"
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(commit)
+        assert version in commit
+        assert "gitlab" in commit
+        assert (
+            "https://gitlab.gnome.org/world/phosh/phosh/-/compare/v0.20.0...v" in commit
+        )

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -1,6 +1,8 @@
 { pkgs ? import <nixpkgs> {} }:
 {
   crate = pkgs.callPackage ./crate.nix {};
+  github = pkgs.callPackage ./github.nix {};
+  gitlab = pkgs.callPackage ./gitlab.nix {};
   pypi = pkgs.python3.pkgs.callPackage ./pypi.nix {};
   sourcehut = pkgs.python3.pkgs.callPackage ./sourcehut.nix {};
   savanna = pkgs.python3.pkgs.callPackage ./savanna.nix {};

--- a/tests/testpkgs/github.nix
+++ b/tests/testpkgs/github.nix
@@ -1,0 +1,13 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "fd";
+  version = "8.0.0";
+
+  src = fetchFromGitHub {
+    owner = "sharkdp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+}

--- a/tests/testpkgs/gitlab.nix
+++ b/tests/testpkgs/gitlab.nix
@@ -1,0 +1,15 @@
+{ stdenv, fetchFromGitLab }:
+
+stdenv.mkDerivation rec {
+  pname = "phosh";
+  version = "0.20.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "world";
+    owner = "phosh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+}


### PR DESCRIPTION
Adds a diff url to the commit message similar to the changelog feature  #101, e.g.:
Diff: https://github.com/sharkdp/fd/compare/v8.0.0...v8.5.2
Diff: https://gitlab.gnome.org/world/phosh/phosh/-/compare/v0.20.0...v0.22.0

This integration tests are adapted from test_pypi in #101 as well