### PR TITLE
add flag to run passthru.updateScript if possible

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -32,6 +32,12 @@ def parse_args(args: list[str]) -> Options:
         "--commit", action="store_true", help="Commit the updated package"
     )
     parser.add_argument(
+        "-u",
+        "--use-update-script",
+        action="store_true",
+        help="Use passthru.updateScript instead if possible",
+    )
+    parser.add_argument(
         "--write-commit-message",
         metavar="FILE",
         help="Write commit message to FILE",
@@ -65,6 +71,7 @@ def parse_args(args: list[str]) -> Options:
         import_path=a.file,
         build=a.build,
         commit=a.commit,
+        use_update_script=a.use_update_script,
         write_commit_message=a.write_commit_message,
         run=a.run,
         shell=a.shell,

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -34,6 +34,7 @@ class Package:
     cargo_deps: Optional[str]
     npm_deps: Optional[str]
     tests: List[str]
+    has_update_script: bool
 
     raw_version_position: InitVar[Optional[Dict[str, Any]]]
 
@@ -81,6 +82,7 @@ def eval_expression(import_path: str, attr: str) -> str:
       cargo_deps = (pkg.cargoDeps or null).outputHash or null;
       npm_deps = (pkg.npmDeps or null).outputHash or null;
       tests = builtins.attrNames (pkg.passthru.tests or {{}});
+      has_update_script = pkg.passthru.updateScript or null != null;
       src_homepage = pkg.src.meta.homepage or null;
       changelog = pkg.meta.changelog or null;
     }})"""

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -13,6 +13,7 @@ class Options:
     import_path: str = "./."
     override_filename: Optional[str] = None
     commit: bool = False
+    use_update_script: bool = False
     write_commit_message: Optional[str] = None
     shell: bool = False
     run: bool = False

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -1,6 +1,7 @@
 import fileinput
 import subprocess
 import tempfile
+from os import path
 from typing import Dict, Optional
 
 from .errors import UpdateError
@@ -171,6 +172,23 @@ def update_version(
 
 def update(opts: Options) -> Package:
     package = eval_attr(opts)
+
+    if package.has_update_script and opts.use_update_script:
+        run(
+            [
+                "nix-shell",
+                path.join(opts.import_path, "maintainers/scripts/update.nix"),
+                "--argstr",
+                "package",
+                opts.attribute,
+            ],
+            stdout=None,
+        )
+
+        new_package = eval_attr(opts)
+        package.new_version = Version(new_package.old_version, rev=new_package.rev)
+
+        return package
 
     update_hash = True
 


### PR DESCRIPTION
currerntly using `-u` with `--commit` doesn't actually commit if the update script only updates files other the original file (e.g. the `pin.json`s), I'm not sure if there is a good way to do it without changing fundamentally how we detect changes