### PR TITLE
prefer versions with the same prefix

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -139,8 +139,12 @@ def update_version(
     else:
         if not package.parsed_url:
             raise UpdateError("Could not find a url in the derivations src attribute")
+
+        version_prefix = ""
         if preference != VersionPreference.BRANCH:
             branch = None
+            if package.rev and package.rev.endswith(package.old_version):
+                version_prefix = package.rev.removesuffix(package.old_version)
         elif version == "branch":
             # fallback
             branch = "HEAD"
@@ -148,7 +152,12 @@ def update_version(
             assert version.startswith("branch=")
             branch = version[7:]
         new_version = fetch_latest_version(
-            package.parsed_url, preference, version_regex, branch
+            package.parsed_url,
+            preference,
+            version_regex,
+            branch,
+            package.rev,
+            version_prefix,
         )
     package.new_version = new_version
     position = package.version_position

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -60,6 +60,8 @@ def fetch_latest_version(
     preference: VersionPreference,
     version_regex: str,
     branch: Optional[str] = None,
+    old_rev: Optional[str] = None,
+    version_prefix: str = "",
 ) -> Version:
     unstable: List[str] = []
     filtered: List[str] = []
@@ -82,6 +84,23 @@ def fetch_latest_version(
             else:
                 final.append(extracted)
         if final != []:
+            if version_prefix != "":
+                ver = next(
+                    (
+                        Version(
+                            version.number.removeprefix(version_prefix),
+                            prerelease=version.prerelease,
+                            rev=version.number,
+                        )
+                        for version in final
+                        if version.number.startswith(version_prefix)
+                    ),
+                    None,
+                )
+
+                if ver is not None and ver.rev != old_rev:
+                    return ver
+
             return final[0]
 
     if filtered:

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -44,7 +44,12 @@ def extract_version(version: Version, version_regex: str) -> Optional[Version]:
     if match is not None:
         group = match.group(1)
         if group is not None:
-            return Version(group, prerelease=version.prerelease, rev=version.rev)
+            return Version(
+                group,
+                prerelease=version.prerelease,
+                rev=version.rev
+                or (None if version.number == group else version.number),
+            )
     return None
 
 
@@ -90,7 +95,7 @@ def fetch_latest_version(
                         Version(
                             version.number.removeprefix(version_prefix),
                             prerelease=version.prerelease,
-                            rev=version.number,
+                            rev=version.rev or version.number,
                         )
                         for version in final
                         if version.number.startswith(version_prefix)


### PR DESCRIPTION
to test, revert cargo-nextest to the 0.9.43 and run `nix-update cargo-nextest`

before: 0.9.43 -> quick-junit-0.3.2
after: 0.9.43 -> 0.9.44