### PR TITLE
remove trailing `.git` for github diff urls

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -173,7 +173,7 @@ def update_version(
     if package.parsed_url:
         if package.parsed_url.netloc == "github.com":
             _, owner, repo, *_ = package.parsed_url.path.split("/")
-            package.diff_url = f"https://github.com/{owner}/{repo}/compare/{package.rev}...{new_version.rev or new_version.number}"
+            package.diff_url = f"https://github.com/{owner}/{repo.removesuffix('.git')}/compare/{package.rev}...{new_version.rev or new_version.number}"
         elif package.parsed_url.netloc in ["codeberg.org", "gitea.com", "notabug.org"]:
             _, owner, repo, *_ = package.parsed_url.path.split("/")
             package.diff_url = f"https://{package.parsed_url.netloc}/{owner}/{repo}/compare/{package.rev}...{new_version.rev or new_version.number}"


### PR DESCRIPTION
so it doesn't generate broken urls for `fetchSubmodules = true`