### PR TITLE
reject empty hashes

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -105,7 +105,11 @@ def nix_prefetch(opts: Options, attr: str) -> str:
     finally:
         if tempdir:
             tempdir.cleanup()
-    return got
+
+    if got == "":
+        raise UpdateError(f"empty hash when trying to update {opts.attribute}.{attr}")
+    else:
+        return got
 
 
 def disable_check_meta(opts: Options) -> str:


### PR DESCRIPTION
after switching away from nix-prefetch in https://github.com/Mic92/nix-update/commit/5692ffc91d61090679f74e5b6f01c87b97b816eb, nix-update no longer aborts when prefetching the hash fails: https://github.com/NixOS/nixpkgs/pull/215906#issuecomment-1427010640