### PR TITLE
fix updating cargoLock with flakes

### DIFF
--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -148,7 +148,7 @@ in {{
       let
         inherit (pkg.cargoDeps) lockFile;
         res = builtins.tryEval (sanitizePosition {{
-          file = lockFile;
+          file = toString lockFile;
         }});
       in
       if res.success then res.value.file else false


### PR DESCRIPTION
hopefully fixes #153 

using `toString` stops `Cargo.lock` from being copied to the store alone, and makes sure it is still under the directory of the flake, so nix-update is able to find its local path