### PR TITLE
improve version assertions in tests

### DIFF
--- a/tests/test_flake.py
+++ b/tests/test_flake.py
@@ -21,7 +21,7 @@ def test_main(helpers: conftest.Helpers) -> None:
             text=True,
             stdout=subprocess.PIPE,
         ).stdout.strip()
-        assert version >= "8.5.2"
+        assert tuple(map(int, version.split("."))) >= (8, 5, 2)
         commit = subprocess.run(
             ["git", "-C", path, "log", "-1"],
             text=True,

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -23,7 +23,7 @@ def test_main(helpers: conftest.Helpers) -> None:
             text=True,
             stdout=subprocess.PIPE,
         ).stdout.strip()
-        assert version >= "30"
+        assert int(version) >= 30
         commit = subprocess.run(
             ["git", "-C", path, "log", "-1"],
             text=True,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -23,7 +23,7 @@ def test_main(helpers: conftest.Helpers) -> None:
             text=True,
             stdout=subprocess.PIPE,
         ).stdout.strip()
-        assert version >= "8.5.2"
+        assert tuple(map(int, version.split("."))) >= (8, 5, 2)
         commit = subprocess.run(
             ["git", "-C", path, "log", "-1"],
             text=True,

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -23,7 +23,7 @@ def test_main(helpers: conftest.Helpers) -> None:
             text=True,
             stdout=subprocess.PIPE,
         ).stdout.strip()
-        assert version >= "0.22.0"
+        assert tuple(map(int, version.split("."))) >= (0, 22, 0)
         commit = subprocess.run(
             ["git", "-C", path, "log", "-1"],
             text=True,

--- a/tests/test_npm.py
+++ b/tests/test_npm.py
@@ -23,5 +23,5 @@ def test_update(helpers: conftest.Helpers) -> None:
             ],
             text=True,
             stdout=subprocess.PIPE,
-        )
-        assert version.stdout.strip() > "10.8.6"
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) > (10, 8, 6)

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -23,7 +23,7 @@ def test_main(helpers: conftest.Helpers) -> None:
             text=True,
             stdout=subprocess.PIPE,
         ).stdout.strip()
-        assert version >= "3.0.1"
+        assert tuple(map(int, version.split("."))) >= (3, 0, 1)
         commit = subprocess.run(
             ["git", "-C", path, "log", "-1"],
             text=True,

--- a/tests/test_savanna.py
+++ b/tests/test_savanna.py
@@ -23,5 +23,5 @@ def test_update(helpers: conftest.Helpers) -> None:
             ],
             text=True,
             stdout=subprocess.PIPE,
-        )
-        assert version.stdout.strip() >= "0.6.8"
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) >= (0, 6, 8)

--- a/tests/test_sourcehut.py
+++ b/tests/test_sourcehut.py
@@ -23,5 +23,5 @@ def test_update(helpers: conftest.Helpers) -> None:
             ],
             text=True,
             stdout=subprocess.PIPE,
-        )
-        assert version.stdout.strip() >= "0.3.6"
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) >= (0, 3, 6)


### PR DESCRIPTION
fixes broken tests due to flaky string comparisons

```python
AssertionError: assert '10.8.10' > '10.8.6'
```

bors r+