### PR TITLE
remove shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,0 @@
-{ pkgs ? import <nixpkgs> { } }:
-
-with pkgs;
-
-mkShellNoCC {
-  buildInputs = [
-    (import ./. { }).passthru.env
-  ];
-}


### PR DESCRIPTION
It was broken due to the removal of `passthru.env` in #165, `nix-shell` will still work as it will pick up `default.nix`