### PR TITLE
escape attribute names

### DIFF
--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -1,3 +1,4 @@
+import json
 import os
 from dataclasses import dataclass, field
 from typing import List, Optional
@@ -26,3 +27,6 @@ class Options:
     format: bool = False
     system: Optional[str] = None
     extra_flags: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.attribute = json.dumps(self.attribute)


### PR DESCRIPTION
closes #178

it uses `json.dumps` which may not be the most ideal, but it is the easiest way I can think of