### PR TITLE
fix attribute name escaping

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -125,7 +125,7 @@ def nix_shell(options: Options) -> None:
             check=False,
         )
     else:
-        expr = f"with import {options.import_path} {{}}; mkShell {{ buildInputs = [ {options.attribute} ]; }}"
+        expr = f"let pkgs = import {options.import_path} {{}}; in pkgs.mkShell {{ buildInputs = [ pkgs.{options.escaped_attribute} ]; }}"
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, "default.nix")
             with open(path, "w") as f:

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -165,7 +165,9 @@ in {{
 
 
 def eval_attr(opts: Options) -> Package:
-    expr = eval_expression(opts.import_path, opts.attribute, opts.flake, opts.system)
+    expr = eval_expression(
+        opts.import_path, opts.escaped_attribute, opts.flake, opts.system
+    )
     cmd = [
         "nix",
         "eval",

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -29,4 +29,4 @@ class Options:
     extra_flags: List[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        self.attribute = json.dumps(self.attribute)
+        self.escaped_attribute = json.dumps(self.attribute)

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -84,9 +84,9 @@ def replace_hash(filename: str, current: str, target: str) -> None:
 
 def get_package(opts: Options) -> str:
     return (
-        f'(let flake = builtins.getFlake "{opts.import_path}"; in flake.packages.${{builtins.currentSystem}}.{opts.attribute} or flake.{opts.attribute})'
+        f'(let flake = builtins.getFlake "{opts.import_path}"; in flake.packages.${{builtins.currentSystem}}.{opts.escaped_attribute} or flake.{opts.escaped_attribute})'
         if opts.flake
-        else f"(import {opts.import_path} {disable_check_meta(opts)}).{opts.attribute}"
+        else f"(import {opts.import_path} {disable_check_meta(opts)}).{opts.escaped_attribute}"
     )
 
 

--- a/tests/test_flake.py
+++ b/tests/test_flake.py
@@ -29,6 +29,5 @@ def test_main(helpers: conftest.Helpers) -> None:
             check=True,
         ).stdout.strip()
         print(commit)
-        assert version in commit
-        assert "crate" in commit
+        assert f"crate: 8.0.0 -> {version}" in commit
         assert "https://diff.rs/fd-find/8.0.0/" in commit

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -31,8 +31,7 @@ def test_main(helpers: conftest.Helpers) -> None:
             check=True,
         ).stdout.strip()
         print(commit)
-        assert version in commit
-        assert "pypi" in commit
+        assert f"pypi: 2.0.0 -> {version}" in commit
         assert (
             f"https://github.com/Mic92/python-mpd2/blob/{version}/doc/changes.rst"
             in commit


### PR DESCRIPTION
In #179, I introduced a few bugs in e.g. commit messages, this should be able to fix it