### PR TITLE
update source attributes other than `src`

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -87,6 +87,12 @@ def parse_args(args: list[str]) -> Options:
         help="Attribute name within the file evaluated",
     )
 
+    parser.add_argument(
+        "--src-attr",
+        help="Src attribute",
+        default="src",
+    )
+
     a = parser.parse_args(args)
     return Options(
         import_path=os.path.realpath(a.file),
@@ -101,6 +107,7 @@ def parse_args(args: list[str]) -> Options:
         version=a.version,
         version_preference=VersionPreference.from_str(a.version),
         attribute=a.attribute,
+        source_attribute=a.src_attr,
         test=a.test,
         version_regex=a.version_regex,
         review=a.review,

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -91,9 +91,19 @@ class Package:
 
 
 def eval_expression(
-    escaped_import_path: str, attr: str, flake: bool, system: str | None
+    escaped_import_path: str,
+    attr: str,
+    source_attr: str,
+    flake: bool,
+    system: str | None,
 ) -> str:
     system = f'"{system}"' if system else "builtins.currentSystem"
+
+    source_attrs = source_attr.rpartition(".")
+    source_attr_last = source_attrs[-1] or source_attr
+    source_attr_all_but_last = (
+        f".{source_attrs[0]}" if source_attr_last != source_attr else ""
+    )
 
     if flake:
         let_bindings = f"""
@@ -132,17 +142,17 @@ let
   else if pkg ? isPhpExtension then
     raw_version_position
    else
-    sanitizePosition (builtins.unsafeGetAttrPos "src" pkg);
+    sanitizePosition (builtins.unsafeGetAttrPos "{source_attr_last}" pkg{source_attr_all_but_last});
 in {{
   name = pkg.name;
   old_version = pkg.version or (builtins.parseDrvName pkg.name).version;
   inherit raw_version_position;
   filename = position.file;
   line = position.line;
-  urls = pkg.src.urls or null;
-  url = pkg.src.url or null;
-  rev = pkg.src.rev or null;
-  hash = pkg.src.outputHash or null;
+  urls = pkg.{source_attr}.urls or null;
+  url = pkg.{source_attr}.url or null;
+  rev = pkg.{source_attr}.rev or null;
+  hash = pkg.{source_attr}.outputHash or null;
   go_modules = pkg.goModules.outputHash or null;
   go_modules_old = pkg.go-modules.outputHash or null;
   cargo_deps = pkg.cargoDeps.outputHash or null;
@@ -161,14 +171,18 @@ in {{
   yarn_deps = pkg.offlineCache.outputHash or null;
   tests = builtins.attrNames (pkg.passthru.tests or {{}});
   has_update_script = {has_update_script};
-  src_homepage = pkg.src.meta.homepage or null;
+  src_homepage = pkg.{source_attr}.meta.homepage or null;
   changelog = pkg.meta.changelog or null;
 }}"""
 
 
 def eval_attr(opts: Options) -> Package:
     expr = eval_expression(
-        opts.escaped_import_path, opts.escaped_attribute, opts.flake, opts.system
+        opts.escaped_import_path,
+        opts.escaped_attribute,
+        opts.source_attribute,
+        opts.flake,
+        opts.system,
     )
     cmd = [
         "nix",

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -1,6 +1,7 @@
 import json
 import os
 from dataclasses import InitVar, dataclass, field
+from pprint import pprint
 from textwrap import dedent, indent
 from typing import Any, Literal
 from urllib.parse import ParseResult, urlparse
@@ -195,6 +196,7 @@ def eval_attr(opts: Options) -> Package:
     res = run(cmd)
     out = json.loads(res.stdout)
     package = Package(attribute=opts.attribute, import_path=opts.import_path, **out)
+    pprint(package)
     if opts.override_filename is not None:
         package.filename = opts.override_filename
     if opts.url is not None:

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -8,6 +8,7 @@ from .version.version import VersionPreference
 @dataclass
 class Options:
     attribute: str
+    source_attribute: str = "src"
     flake: bool = False
     version: str = "stable"
     version_preference: VersionPreference = VersionPreference.STABLE
@@ -29,4 +30,7 @@ class Options:
 
     def __post_init__(self) -> None:
         self.escaped_attribute = ".".join(map(json.dumps, self.attribute.split(".")))
+        self.escaped_source_attribute = ".".join(
+            map(json.dumps, self.source_attribute.split("."))
+        )
         self.escaped_import_path = json.dumps(self.import_path)

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -141,7 +141,7 @@ def git_prefetch(x: tuple[str, tuple[str, str]]) -> tuple[str, str]:
 
 
 def update_src_hash(opts: Options, filename: str, current_hash: str) -> None:
-    target_hash = nix_prefetch(opts, "src")
+    target_hash = nix_prefetch(opts, opts.source_attribute)
     replace_hash(filename, current_hash, target_hash)
 
 


### PR DESCRIPTION
Motivation is to update packages such as [catppuccin](https://github.com/NixOS/nixpkgs/blob/master/pkgs/data/themes/catppuccin/default.nix) CC @khaneliman and [lambda-lisp](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/lambda-lisp/default.nix) CC @cafkafk

Diff Setting `bat` source to an old version and adding `sources` to `passthru`
```diff
diff --git a/pkgs/data/themes/catppuccin/default.nix b/pkgs/data/themes/catppuccin/default.nix
index 16befcd06b81..46214c6ed74b 100644
--- a/pkgs/data/themes/catppuccin/default.nix
+++ b/pkgs/data/themes/catppuccin/default.nix
@@ -20,8 +20,8 @@ let
       name = "bat";
       owner = "catppuccin";
       repo = "bat";
-      rev = "ba4d16880d63e656acced2b7d4e034e4a93f74b1";
-      hash = "sha256-6WVKQErGdaqb++oaXnY3i6/GuH2FhTgK0v4TN4Y0Wbw=";
+      rev = "00bd462e8fab5f74490335dcf881ebe7784d23fa";
+      hash = "sha256-yzn+1IXxQaKcCK7fBdjtVohns0kbN+gcqbWVE4Bx7G8=";
     };
 
     bottom = fetchFromGitHub {
@@ -102,6 +102,8 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
+  passthru = { inherit sources; };
+
   meta = {
     description = "Soothing pastel themes";
     homepage = "https://github.com/catppuccin/catppuccin";
```

`nix-update "catppuccin" --src-attr "sources.bat"`

It would be nice to be able to use `nix-update` to update such sources instead of a custom update script


Related https://github.com/Mic92/nix-update/issues/163 because being able to pass `catppuccin.sources.bat` would fix this issue too.