### PR TITLE
improve --help output, notably '--version' possibilities

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -65,7 +65,8 @@ def parse_args(args: list[str]) -> Options:
         "--shell", action="store_true", help="provide a shell with the package"
     )
     parser.add_argument(
-        "--version", nargs="?", help="Version to update to", default="stable"
+        "--version", nargs="?", default=VersionPreference.STABLE,
+        help="Version to update to. Possible values are: " + ', '.join(VersionPreference),
     )
     parser.add_argument(
         "--override-filename",
@@ -84,7 +85,7 @@ def parse_args(args: list[str]) -> Options:
         "attribute",
         default=default_attribute,
         nargs="?" if default_attribute else None,  # type: ignore
-        help="Attribute name within the file evaluated",
+        help='''Attribute name within the file evaluated (defaults to environment variable "UPDATE_NIX_ATTR_PATH")''',
     )
 
     a = parser.parse_args(args)
@@ -309,7 +310,7 @@ def main(args: list[str] = sys.argv[1:]) -> None:
 
     if options.review:
         if options.flake:
-            print("--review is unsupporetd with --flake")
+            print("--review is unsupported with --flake")
         else:
             nixpkgs_review()
 

--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -65,8 +65,11 @@ def parse_args(args: list[str]) -> Options:
         "--shell", action="store_true", help="provide a shell with the package"
     )
     parser.add_argument(
-        "--version", nargs="?", default=VersionPreference.STABLE,
-        help="Version to update to. Possible values are: " + ', '.join(VersionPreference),
+        "--version",
+        nargs="?",
+        default=VersionPreference.STABLE,
+        help="Version to update to. Possible values are: "
+        + ", ".join(VersionPreference),
     )
     parser.add_argument(
         "--override-filename",
@@ -85,7 +88,7 @@ def parse_args(args: list[str]) -> Options:
         "attribute",
         default=default_attribute,
         nargs="?" if default_attribute else None,  # type: ignore
-        help='''Attribute name within the file evaluated (defaults to environment variable "UPDATE_NIX_ATTR_PATH")''',
+        help="""Attribute name within the file evaluated (defaults to environment variable "UPDATE_NIX_ATTR_PATH")""",
     )
 
     a = parser.parse_args(args)

--- a/nix_update/version/version.py
+++ b/nix_update/version/version.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import Enum, auto
+from enum import StrEnum, auto
 
 
 @dataclass
@@ -9,7 +9,7 @@ class Version:
     rev: str | None = None
 
 
-class VersionPreference(Enum):
+class VersionPreference(StrEnum):
     STABLE = auto()
     UNSTABLE = auto()
     FIXED = auto()


### PR DESCRIPTION
I was trying to update nixpkgs's nelua with the latest commit but that surprisingly obscure from the doc.
-  `nix-update --version=unstable` updated the version with a tag without updating the src ?! what does 'unstable' refer to ?
- I finally found that nix-update --version=branch=master would work by looking at the code.

If you can explain those to me, maybe I can improve the parser's doc.
