### PR TITLE
Change hash attr to algo agnostic one (sha256 -> hash, cargoSha256 -> cargoHash)

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -78,6 +78,9 @@ def replace_hash(filename: str, current: str, target: str) -> None:
         with fileinput.FileInput(filename, inplace=True) as f:
             for line in f:
                 line = line.replace(current, normalized_hash)
+                # Also update hash attr name
+                line = re.sub(r"sha256\s*=\s*", r"hash = ", line)
+                line = re.sub(r"Sha256\s*=\s*", r"Hash = ", line)
                 print(line, end="")
 
 


### PR DESCRIPTION
As requested previously in https://github.com/Mic92/nix-update/issues/177, this change can help with minimizing the nitpicks on new nixpkgs PRs because of the new fetchers' hash attribute name conventions.

This works for:
 - `sha256` -> `hash`
 - `cargoSha256` -> `cargoHash`
 - `vendorSha256` -> `vendorHash`
 - and more

Note: It currently only supports `sha256` hashes as I saw that in a couple of lines below we only get the hash for `sha256` anyway, also, the other algorithms aren't that popular anyway.
