### PR TITLE
Add support for updating buildComposerProject's vendorHash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.direnv
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ designed to work with nixpkgs but also other package sets.
 - update buildRustPackage's cargoHash/cargoSha256 and cargoSetupHook's cargoDeps
 - update buildGoModule's vendorHash/vendorSha256
 - update buildNpmPackage's npmDepsHash and npmConfigHook's npmDeps
+- update buildComposerProject's vendorHash
 - update fetchYarnDeps offlineCache output hash
 - update flake outputs (see `--flake`)
 - build and run the resulting package (see `--build`,

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -54,6 +54,7 @@ class Package:
     cargo_deps: str | None
     npm_deps: str | None
     yarn_deps: str | None
+    composer_deps: str | None
     tests: list[str]
     has_update_script: bool
 
@@ -157,6 +158,7 @@ in {{
       if res.success then res.value.file else false
     else
       null;
+  composer_deps = pkg.composerRepository.outputHash or null;
   npm_deps = pkg.npmDeps.outputHash or null;
   yarn_deps = pkg.offlineCache.outputHash or null;
   tests = builtins.attrNames (pkg.passthru.tests or {{}});

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -243,6 +243,11 @@ def update_cargo_lock(
                 print(line, end="")
 
 
+def update_composer_deps_hash(opts: Options, filename: str, current_hash: str) -> None:
+    target_hash = nix_prefetch(opts, "composerRepository")
+    replace_hash(filename, current_hash, target_hash)
+
+
 def print_hashes(hashes: dict[str, str], indent: str) -> None:
     if not hashes:
         return
@@ -366,6 +371,9 @@ def update(opts: Options) -> Package:
             package.cargo_lock, CargoLockInStore
         ):
             update_cargo_lock(opts, package.filename, package.cargo_lock)
+
+        if package.composer_deps:
+            update_composer_deps_hash(opts, package.filename, package.composer_deps)
 
         if package.npm_deps:
             update_npm_deps_hash(opts, package.filename, package.npm_deps)

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -1,0 +1,27 @@
+import subprocess
+
+import conftest
+
+from nix_update.options import Options
+from nix_update.update import update
+
+
+def test_update(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs() as path:
+        opts = Options(attribute="composer", import_path=str(path))
+        update(opts)
+        version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "composer.version",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) > (10, 8, 6)

--- a/tests/testpkgs/composer.nix
+++ b/tests/testpkgs/composer.nix
@@ -1,0 +1,17 @@
+{ fetchFromGitHub
+, php
+}:
+
+php.buildComposerProject (finalAttrs: {
+  pname = "castor";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "jolicode";
+    repo = "castor";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+})

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -4,7 +4,7 @@
   bitbucket-snapshot = pkgs.callPackage ./bitbucket.nix { isSnapshot = true; };
   cargoLock.expand = pkgs.callPackage ./cargo-lock-expand { };
   cargoLock.update = pkgs.callPackage ./cargo-lock-update { };
-  composer.update = pkgs.callPackage ./composer.nix { };
+  composer = pkgs.callPackage ./composer.nix { };
   crate = pkgs.callPackage ./crate.nix { };
   gitea = pkgs.callPackage ./gitea.nix { };
   github = pkgs.callPackage ./github.nix { };

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -4,6 +4,7 @@
   bitbucket-snapshot = pkgs.callPackage ./bitbucket.nix { isSnapshot = true; };
   cargoLock.expand = pkgs.callPackage ./cargo-lock-expand { };
   cargoLock.update = pkgs.callPackage ./cargo-lock-update { };
+  composer.update = pkgs.callPackage ./composer.nix { };
   crate = pkgs.callPackage ./crate.nix { };
   gitea = pkgs.callPackage ./gitea.nix { };
   github = pkgs.callPackage ./github.nix { };


### PR DESCRIPTION
Hi,

I hope this PR is fine, I mostly did copy/paste pasta from other pull requests and it worked but I may have missed some things.

I adds the support for `buildComposerProject` which allows to build PHP projects: https://nixos.org/manual/nixpkgs/stable/index.html#ssec-building-php-projects.

Kind regards :)