### PR TITLE
Add option for version_key

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -18,7 +18,9 @@ def die(msg: str) -> NoReturn:
 
 
 def parse_args(args: list[str]) -> Options:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
     help = "File to import rather than default.nix. Examples, ./release.nix"
     parser.add_argument("-f", "--file", default="./.", help=help)
     parser.add_argument(
@@ -55,6 +57,12 @@ def parse_args(args: list[str]) -> Options:
         "--version-regex",
         help="Regex to extract version with, i.e. 'jq-(.*)'",
         default="(.*)",
+    )
+    parser.add_argument(
+        "-vk",
+        "--version-key",
+        help="Key of attribute that holds the version",
+        default="version",
     )
     parser.add_argument(
         "--run",
@@ -107,6 +115,7 @@ def parse_args(args: list[str]) -> Options:
         attribute=a.attribute,
         test=a.test,
         version_regex=a.version_regex,
+        version_key=a.version_key,
         review=a.review,
         format=a.format,
         override_filename=a.override_filename,

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -91,7 +91,11 @@ class Package:
 
 
 def eval_expression(
-    escaped_import_path: str, attr: str, flake: bool, system: str | None
+    escaped_import_path: str,
+    attr: str,
+    flake: bool,
+    version_key: str,
+    system: str | None,
 ) -> str:
     system = f'"{system}"' if system else "builtins.currentSystem"
 
@@ -135,7 +139,7 @@ let
     sanitizePosition (builtins.unsafeGetAttrPos "src" pkg);
 in {{
   name = pkg.name;
-  old_version = pkg.version or (builtins.parseDrvName pkg.name).version;
+  old_version = pkg.{version_key} or (builtins.parseDrvName pkg.name).{version_key};
   inherit raw_version_position;
   filename = position.file;
   line = position.line;
@@ -168,7 +172,11 @@ in {{
 
 def eval_attr(opts: Options) -> Package:
     expr = eval_expression(
-        opts.escaped_import_path, opts.escaped_attribute, opts.flake, opts.system
+        opts.escaped_import_path,
+        opts.escaped_attribute,
+        opts.flake,
+        opts.version_key,
+        opts.system,
     )
     cmd = [
         "nix",

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -12,6 +12,7 @@ class Options:
     version: str = "stable"
     version_preference: VersionPreference = VersionPreference.STABLE
     version_regex: str = "(.*)"
+    version_key: str = "version"
     import_path: str = os.getcwd()
     override_filename: str | None = None
     url: str | None = None

--- a/tests/test_versionkey.py
+++ b/tests/test_versionkey.py
@@ -1,0 +1,29 @@
+import subprocess
+
+import conftest
+
+from nix_update.options import Options
+from nix_update.update import update
+
+
+def test_update(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs() as path:
+        opts = Options(
+            attribute="versionkey", import_path=str(path), version_key="immich_version"
+        )
+        update(opts)
+        version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "versionkey.immich_version",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) >= (1, 91, 0)

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -12,4 +12,5 @@
   sourcehut = pkgs.python3.pkgs.callPackage ./sourcehut.nix { };
   savanna = pkgs.python3.pkgs.callPackage ./savanna.nix { };
   npm = pkgs.callPackage ./npm.nix { };
+  versionkey = pkgs.callPackage ./versionkey.nix { };
 }

--- a/tests/testpkgs/versionkey.nix
+++ b/tests/testpkgs/versionkey.nix
@@ -1,0 +1,22 @@
+{ buildNpmPackage
+, fetchFromGitHub
+}:
+buildNpmPackage rec {
+  pname = "immich-cli";
+  # version of immich and immich cli differes
+  version = (builtins.fromJSON (builtins.readFile "${src}/cli/package.json")).version;
+
+  immich_version = "1.91.0";
+  src = fetchFromGitHub {
+    owner = "immich-app";
+    repo = "immich";
+    rev = "v${immich_version}";
+    hash = "sha256-tFaa2rN4iGMlrPjHqSbMOE2xbyJh7Ro+Fm8j0+wa1MM=";
+  };
+
+  npmDepsHash = "sha256-NvU+v8MrwPK6q8RdVEHhzi5g6qRRmdTtInf7o2E5y6Y=";
+
+  postPatch = ''
+    cd cli
+  '';
+}


### PR DESCRIPTION
Hi, I was having some problems with packaging with different versioning, so I copied this idea from `common-updater-scripts` from nixpkgs.

Some packages can have a different version from the source repo but could be derived from source. Currently I see no way to update these packages like this with `nix-update`.
This PR adds an option `version_key` for this case.
By expose a variable that holds the github repo version, `nix-update *name* --version-key *version attr name*` could update the package.

BTW, I added an option to the argparser so it shows the default values of options on `--help`.

Thanks!