### PR TITLE
Update README.md to precise that software is available in latest stable channel (23.11 as of today)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ designed to work with nixpkgs but also other package sets.
 
 ## Installation
 
-`nix-update` is included in nixpkgs (unstable channel, right
-now) or [NUR](https://github.com/nix-community/NUR)
-(nur.repos.mic92.nix-update).
+`nix-update` is included in nixpkgs.
 
 To use it run without installing it, use:
 


### PR DESCRIPTION
Update the README to precise that the software is also in the latest stable channel, currently 23.11, shows that it has version 1.0.0 of nix-update (https://search.nixos.org/packages?channel=23.11&show=nix-update&from=0&size=50&sort=relevance&type=packages&query=nix-update)