### PR TITLE
make gitlab updater work by tag when releases are disabled

### DIFF
--- a/nix_update/version/gitlab.py
+++ b/nix_update/version/gitlab.py
@@ -30,7 +30,7 @@ def fetch_gitlab_versions(url: ParseResult) -> list[Version]:
     for tag in json_tags:
         name = tag["name"]
         assert isinstance(name, str)
-        if tag["release"]:
+        if tag.get("release"):
             # TODO: has gitlab preleases?
             releases.append(Version(name))
         else:


### PR DESCRIPTION
If a GitLab repository has the "Releases" feature disabled (such as [vcard](https://gitlab.com/engmark/vcard)), the updater currently fails with `KeyError: 'release'` since the release key is removed from the API

This allows it to gracefully fall back to using tags even if releases are disabled