### PR TITLE
print maintainers list

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -290,6 +290,14 @@ def main(args: list[str] = sys.argv[1:]) -> None:
 
     package = update(options)
 
+    if package.maintainers:
+        print("Package maintainers:")
+        for maintainer in package.maintainers:
+            print(
+                f"  - {maintainer['name']}"
+                + (f" (@{maintainer['github']})" if "github" in maintainer else "")
+            )
+
     if options.build:
         nix_build(options)
 

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -47,6 +47,7 @@ class Package:
     url: str | None
     src_homepage: str | None
     changelog: str | None
+    maintainers: list[dict[str, str]] | None
     rev: str
     hash: str | None
     go_modules: str | None
@@ -165,6 +166,7 @@ in {{
   has_update_script = {has_update_script};
   src_homepage = pkg.src.meta.homepage or null;
   changelog = pkg.meta.changelog or null;
+  maintainers = pkg.meta.maintainers or null;
 }}"""
 
 


### PR DESCRIPTION
## Description
This patch scraps the maintainers list from the package's metadata and displays it.

## Motivation
When making a PR for updating a package, one has to tag the maintainers. Thus, I always find myself manually opening the source file of the package I update just to check the names of the maintainers.
Furthermore, their github handles are not always the same as their name and sometimes have to be looked up for in `maintainers/maintainer-list.nix`.

## Preview
```
...
  maintainers = pkg.meta.maintainers or null;
  changelog = pkg.meta.changelog or null;
} --extra-experimental-features flakes nix-command
fetch https://github.com/astral-sh/ruff-lsp/releases.atom
Not updating version, already 0.0.50
Package maintainers:
  - figsoda (@figsoda)
  - Konstantin Alekseev (@kalekseev)
$ git -C /home/gaetan/perso/nix/nixpkgs diff -- /home/gaetan/perso/nix/nixpkgs/pkgs/development/tools/language-servers/ruff-lsp/default.nix
```

EDIT: In the terminal (mine at least), it appears in white, whereas the rest of the text is green, which makes it nicely visible.