### PR TITLE
fix updating cargo lock when separateDebugInfo is enabled

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -178,6 +178,7 @@ def update_cargo_lock(
     exit
   '';
   outputs = [ "out" ];
+  separateDebugInfo = false;
 }})
 """,
         ]


### PR DESCRIPTION
Without this, the build may error out with `builder for '...' failed to produce output path for output 'debug'`