### PR TITLE
Remove wrongly advertised support for notabug.com, make `fetch_gitea_snapshots` less expensive and fix `fetchFromGitea`'s fallback behaviour to `fetchgit` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ designed to work with nixpkgs but also other package sets.
   - Gitea
   - GitHub
   - GitLab
-  - NotABug.org
   - PyPi
   - RubyGems.org
   - Sourcehut

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -323,7 +323,7 @@ def update_version(
         elif package.parsed_url.netloc == "github.com":
             _, owner, repo, *_ = package.parsed_url.path.split("/")
             package.diff_url = f"https://github.com/{owner}/{repo.removesuffix('.git')}/compare/{package.rev}...{new_version.rev or new_version.number}"
-        elif package.parsed_url.netloc in ["codeberg.org", "gitea.com", "notabug.org"]:
+        elif package.parsed_url.netloc in ["codeberg.org", "gitea.com"]:
             _, owner, repo, *_ = package.parsed_url.path.split("/")
             package.diff_url = f"https://{package.parsed_url.netloc}/{owner}/{repo}/compare/{package.rev}...{new_version.rev or new_version.number}"
         elif GITLAB_API.match(package.parsed_url.geturl()) and package.src_homepage:

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -133,5 +133,5 @@ def fetch_latest_version(
         )
 
     raise VersionError(
-        "Please specify the version. We can only get the latest version from codeberg/crates.io/gitea/github/gitlab/notabug/pypi/savannah/sourcehut/rubygems projects right now"
+        "Please specify the version. We can only get the latest version from codeberg/crates.io/gitea/github/gitlab/pypi/savannah/sourcehut/rubygems projects right now"
     )

--- a/nix_update/version/gitea.py
+++ b/nix_update/version/gitea.py
@@ -6,7 +6,7 @@ from .version import Version
 
 
 def fetch_gitea_versions(url: ParseResult) -> list[Version]:
-    if url.netloc not in ["codeberg.org", "gitea.com", "notabug.org"]:
+    if url.netloc not in ["codeberg.org", "gitea.com"]:
         return []
 
     _, owner, repo, *_ = url.path.split("/")
@@ -17,7 +17,7 @@ def fetch_gitea_versions(url: ParseResult) -> list[Version]:
 
 
 def fetch_gitea_snapshots(url: ParseResult, branch: str) -> list[Version]:
-    if url.netloc not in ["codeberg.org", "gitea.com", "notabug.org"]:
+    if url.netloc not in ["codeberg.org", "gitea.com"]:
         return []
 
     _, owner, repo, *_ = url.path.split("/")

--- a/nix_update/version/gitea.py
+++ b/nix_update/version/gitea.py
@@ -21,7 +21,7 @@ def fetch_gitea_snapshots(url: ParseResult, branch: str) -> list[Version]:
         return []
 
     _, owner, repo, *_ = url.path.split("/")
-    commits_url = f"https://{url.netloc}/api/v1/repos/{owner}/{repo}/commits?sha={branch}&limit=1stat=false"
+    commits_url = f"https://{url.netloc}/api/v1/repos/{owner}/{repo}/commits?sha={branch}&limit=1&stat=false&verification=false&files=false"
     resp = urlopen(commits_url)
     commits = json.loads(resp.read())
 

--- a/nix_update/version/gitea.py
+++ b/nix_update/version/gitea.py
@@ -1,4 +1,5 @@
 import json
+import re
 from urllib.parse import ParseResult
 from urllib.request import urlopen
 
@@ -10,6 +11,7 @@ def fetch_gitea_versions(url: ParseResult) -> list[Version]:
         return []
 
     _, owner, repo, *_ = url.path.split("/")
+    repo = re.sub(r"\.git$", "", repo)
     tags_url = f"https://{url.netloc}/api/v1/repos/{owner}/{repo}/tags"
     resp = urlopen(tags_url)
     tags = json.loads(resp.read())
@@ -21,6 +23,7 @@ def fetch_gitea_snapshots(url: ParseResult, branch: str) -> list[Version]:
         return []
 
     _, owner, repo, *_ = url.path.split("/")
+    repo = re.sub(r"\.git$", "", repo)
     commits_url = f"https://{url.netloc}/api/v1/repos/{owner}/{repo}/commits?sha={branch}&limit=1&stat=false&verification=false&files=false"
     resp = urlopen(commits_url)
     commits = json.loads(resp.read())


### PR DESCRIPTION
Please refer to the commit messages for details.

Note: `fetchFromGitLab` has the same `fetchgit` fallback behavior and as such it is also affected by the same issue.