### PR TITLE
 Try pkg.meta.position before unsafeGetAttrPos

### DIFF
--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -142,13 +142,22 @@ def eval_expression(
     return f"""
 let
   {indent(dedent(let_bindings), "  ")}
+  positionFromMeta = pkg: let
+    parts = builtins.match "(.*):([0-9]+)" pkg.meta.position;
+  in {{
+    file = builtins.elemAt parts 0;
+    line = builtins.fromJSON (builtins.elemAt parts 1);
+  }};
+
   raw_version_position = sanitizePosition (builtins.unsafeGetAttrPos "version" pkg);
 
-  position = if pkg ? isRubyGem then
+  position = if pkg ? meta.position then
+    sanitizePosition (positionFromMeta pkg)
+  else if pkg ? isRubyGem then
     raw_version_position
   else if pkg ? isPhpExtension then
     raw_version_position
-   else
+  else
     sanitizePosition (builtins.unsafeGetAttrPos "src" pkg);
 in {{
   name = pkg.name;


### PR DESCRIPTION
Some package builders set `meta.position` manually due to clobbering the origin of `src`.

Fixes `nix-update -u mpvScripts.*`, discovered while reviewing https://github.com/NixOS/nixpkgs/pull/308062.