### PR TITLE
use `nixfmt` with `--format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ tested. Additionally, the `--review` flag can be used to
 initiate a run of [nixpkgs-review](https://github.com/Mic92/nixpkgs-review), which will ensure all
 dependent packages can be built. In order to ensure consistent
 formatting, the `--format` flag will invoke
-[nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt).
+[nixfmt](https://github.com/NixOS/nixfmt).
 
 ```console
 # Also runs nix-build

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ pkgs.python311.pkgs.buildPythonApplication {
   makeWrapperArgs = [
     "--prefix PATH"
     ":"
-    (pkgs.lib.makeBinPath [ pkgs.nixVersions.stable or pkgs.nix_2_4 pkgs.nixpkgs-review pkgs.nix-prefetch-git pkgs.nixfmt-rfc-style ])
+    (pkgs.lib.makeBinPath [ pkgs.nixVersions.stable or pkgs.nix_2_4 pkgs.nixpkgs-review pkgs.nix-prefetch-git ])
   ];
   shellHook = ''
     # workaround because `python setup.py develop` breaks for me

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ pkgs.python311.pkgs.buildPythonApplication {
   makeWrapperArgs = [
     "--prefix PATH"
     ":"
-    (pkgs.lib.makeBinPath [ pkgs.nixVersions.stable or pkgs.nix_2_4 pkgs.nixpkgs-review pkgs.nix-prefetch-git ])
+    (pkgs.lib.makeBinPath [ pkgs.nixVersions.stable or pkgs.nix_2_4 pkgs.nixpkgs-review pkgs.nix-prefetch-git pkgs.nixfmt-rfc-style ])
   ];
   shellHook = ''
     # workaround because `python setup.py develop` breaks for me

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698882062,
-        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699343069,
-        "narHash": "sha256-s7BBhyLA6MI6FuJgs4F/SgpntHBzz40/qV0xLPW6A1Q=",
+        "lastModified": 1716190602,
+        "narHash": "sha256-xYRimrR0duWvokWQEvB87bSsICeCvvX9DxpUOzCfsDE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec750fd01963ab6b20ee1f0cb488754e8036d89d",
+        "rev": "5a5ac83292c7842072318f57d68a48474f8bd34d",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698438538,
-        "narHash": "sha256-AWxaKTDL3MtxaVTVU5lYBvSnlspOS0Fjt8GxBgnU0Do=",
+        "lastModified": 1715940852,
+        "narHash": "sha256-wJqHMg/K6X3JGAE9YLM0LsuKrKb4XiBeVaoeMNlReZg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5deb8dc125a9f83b65ca86cf0c8167c46593e0b1",
+        "rev": "2fba33a182602b9d49f0b2440513e5ee091d838b",
         "type": "github"
       },
       "original": {

--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -31,7 +31,7 @@ def parse_args(args: list[str]) -> Options:
     parser.add_argument(
         "--review", action="store_true", help="Run `nixpkgs-review wip`"
     )
-    parser.add_argument("--format", action="store_true", help="Run `nixpkgs-fmt`")
+    parser.add_argument("--format", action="store_true", help="Run `nixfmt`")
     parser.add_argument(
         "--commit", action="store_true", help="Commit the updated package"
     )
@@ -326,7 +326,7 @@ def main(args: list[str] = sys.argv[1:]) -> None:
             nixpkgs_review()
 
     if options.format:
-        run(["nixpkgs-fmt", package.filename], stdout=None)
+        run(["nixfmt", package.filename], stdout=None)
 
     if options.commit:
         assert git_dir is not None

--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -27,8 +27,7 @@ from .version import Version, VersionPreference
 
 
 class SnapshotFetcher(Protocol):
-    def __call__(self, url: ParseResult, branch: str) -> list[Version]:
-        ...
+    def __call__(self, url: ParseResult, branch: str) -> list[Version]: ...
 
 
 fetchers: list[Callable[[ParseResult], list[Version]]] = [


### PR DESCRIPTION
following [rfc 166](https://github.com/NixOS/rfcs/pull/166), [nixfmt](https://github.com/NixOS/nixfmt) is now the official formatter for nix and slowing becoming more commonplace in both nixpkgs and the community. though it isn't stable just yet, i think it might be good to start using it sooner rather than later
