### PR TITLE
Add support for updating pnpmDeps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716190602,
-        "narHash": "sha256-xYRimrR0duWvokWQEvB87bSsICeCvvX9DxpUOzCfsDE=",
+        "lastModified": 1717681334,
+        "narHash": "sha256-HlvsMH8BNgdmQCwbBDmWp5/DfkEQYhXZHagJQCgbJU0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a5ac83292c7842072318f57d68a48474f8bd34d",
+        "rev": "31f40991012489e858517ec20102f033e4653afb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,13 @@
         packages.nix-update = pkgs.callPackage ./. { };
         packages.default = config.packages.nix-update;
 
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ config.packages.default ];
+
+          # Make tests use our pinned Nixpkgs
+          env.NIX_PATH = "nixpkgs=${pkgs.path}";
+        };
+
         checks =
           let
             packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages;

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -54,6 +54,7 @@ class Package:
     go_modules_old: str | None
     cargo_deps: str | None
     npm_deps: str | None
+    pnpm_deps: str | None
     yarn_deps: str | None
     composer_deps: str | None
     maven_deps: str | None
@@ -185,6 +186,7 @@ in {{
       null;
   composer_deps = pkg.composerRepository.outputHash or null;
   npm_deps = pkg.npmDeps.outputHash or null;
+  pnpm_deps = pkg.pnpmDeps.outputHash or null;
   yarn_deps = pkg.offlineCache.outputHash or null;
   maven_deps = pkg.fetchedMavenDeps.outputHash or null;
   tests = builtins.attrNames (pkg.passthru.tests or {{}});

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -261,6 +261,11 @@ def print_hashes(hashes: dict[str, str], indent: str) -> None:
     print(f"{indent}}};")
 
 
+def update_pnpm_deps_hash(opts: Options, filename: str, current_hash: str) -> None:
+    target_hash = nix_prefetch(opts, "pnpmDeps")
+    replace_hash(filename, current_hash, target_hash)
+
+
 def update_npm_deps_hash(opts: Options, filename: str, current_hash: str) -> None:
     target_hash = nix_prefetch(opts, "npmDeps")
     replace_hash(filename, current_hash, target_hash)
@@ -389,6 +394,9 @@ def update(opts: Options) -> Package:
 
         if package.npm_deps:
             update_npm_deps_hash(opts, package.filename, package.npm_deps)
+
+        if package.pnpm_deps:
+            update_pnpm_deps_hash(opts, package.filename, package.pnpm_deps)
 
         if package.yarn_deps:
             update_yarn_deps_hash(opts, package.filename, package.yarn_deps)

--- a/tests/test_pnpm.py
+++ b/tests/test_pnpm.py
@@ -1,0 +1,27 @@
+import subprocess
+
+import conftest
+
+from nix_update.options import Options
+from nix_update.update import update
+
+
+def test_update(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs() as path:
+        opts = Options(attribute="pnpm", import_path=str(path))
+        update(opts)
+        pnpm_hash = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "pnpm.pnpmDeps.outputHash",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert pnpm_hash != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -14,5 +14,6 @@
   savanna = pkgs.python3.pkgs.callPackage ./savanna.nix { };
   npm = pkgs.callPackage ./npm.nix { };
   npm-package = pkgs.callPackage ./npm-package.nix { };
+  pnpm = pkgs.callPackage ./pnpm.nix { };
   maven = pkgs.callPackage ./maven.nix { };
 }

--- a/tests/testpkgs/pnpm.nix
+++ b/tests/testpkgs/pnpm.nix
@@ -1,0 +1,21 @@
+{ fetchFromGitHub
+, pnpm_8
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vesktop";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "Vencord";
+    repo = "Vesktop";
+    rev = "v${version}";
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  pnpmDeps = pnpm_8.fetchDeps {
+    inherit pname version src;
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+}


### PR DESCRIPTION
Now that https://github.com/NixOS/nixpkgs/pull/290715, it would be nice to have some update tooling :D

You can test this with the package `pot`, as it is one patch version behind on master.

https://github.com/pot-app/pot-desktop/releases
