### PR TITLE
version: add prerelease to unstable pattern

### DIFF
--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -72,7 +72,7 @@ def extract_version(version: Version, version_regex: str) -> Version | None:
 def is_unstable(version: Version, extracted: str) -> bool:
     if version.prerelease is not None:
         return version.prerelease
-    pattern = "rc|alpha|beta|preview|nightly|m[0-9]+"
+    pattern = "rc|alpha|beta|preview|nightly|prerelease|m[0-9]+"
     return re.search(pattern, extracted, re.IGNORECASE) is not None
 
 


### PR DESCRIPTION
Some packages use the `-prerelease` tag to indicate prereleases, and that's not currently detected by the `is_unstable` pattern. Here's a sample PR where the bot tries to update to a prerelease with this pattern: https://github.com/NixOS/nixpkgs/pull/306846