### PR TITLE
update Cargo.lock after other hashes

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -384,11 +384,6 @@ def update(opts: Options) -> Package:
         if package.cargo_deps:
             update_cargo_deps_hash(opts, package.filename, package.cargo_deps)
 
-        if isinstance(package.cargo_lock, CargoLockInSource) or isinstance(
-            package.cargo_lock, CargoLockInStore
-        ):
-            update_cargo_lock(opts, package.filename, package.cargo_lock)
-
         if package.composer_deps:
             update_composer_deps_hash(opts, package.filename, package.composer_deps)
 
@@ -403,5 +398,10 @@ def update(opts: Options) -> Package:
 
         if package.maven_deps:
             update_maven_deps_hash(opts, package.filename, package.maven_deps)
+
+        if isinstance(package.cargo_lock, CargoLockInSource) or isinstance(
+            package.cargo_lock, CargoLockInStore
+        ):
+            update_cargo_lock(opts, package.filename, package.cargo_lock)
 
     return package


### PR DESCRIPTION
As `update_cargo_lock()` overrides the top level derivations, this will cause hash mismatch errors in the event of other FODs being used in the environment (i.e., `pnpmDeps`) during updates if they also need to be updated. `gitbutler` in nixpkgs at [this](https://github.com/NixOS/nixpkgs/tree/e6e4cd92ad886b91a6de120ce61c81b7e6072530/pkgs/by-name/gi/gitbutler) revision is a real world example of this occurring, and changing the order of these function calls allows it to run as expected
