### PR TITLE
Add support for updating Mix dependencies for Elixir projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ designed to work with nixpkgs but also other package sets.
 - update buildNpmPackage's npmDepsHash and npmConfigHook's npmDeps
 - update buildComposerProject's vendorHash
 - update buildMavenPackage's mvnHash
+- update mixRelease's mixFodDeps
 - update fetchYarnDeps offlineCache output hash
 - update flake outputs (see `--flake`)
 - build and run the resulting package (see `--build`,

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -58,6 +58,7 @@ class Package:
     yarn_deps: str | None
     composer_deps: str | None
     maven_deps: str | None
+    mix_deps: str | None
     tests: list[str]
     has_update_script: bool
 
@@ -189,6 +190,7 @@ in {{
   pnpm_deps = pkg.pnpmDeps.outputHash or null;
   yarn_deps = pkg.offlineCache.outputHash or null;
   maven_deps = pkg.fetchedMavenDeps.outputHash or null;
+  mix_deps = pkg.mixFodDeps.outputHash or null;
   tests = builtins.attrNames (pkg.passthru.tests or {{}});
   has_update_script = {has_update_script};
   src_homepage = pkg.src.meta.homepage or null;

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -281,6 +281,11 @@ def update_maven_deps_hash(opts: Options, filename: str, current_hash: str) -> N
     replace_hash(filename, current_hash, target_hash)
 
 
+def update_mix_deps_hash(opts: Options, filename: str, current_hash: str) -> None:
+    target_hash = nix_prefetch(opts, "mixFodDeps")
+    replace_hash(filename, current_hash, target_hash)
+
+
 def update_version(
     package: Package, version: str, preference: VersionPreference, version_regex: str
 ) -> bool:
@@ -398,6 +403,9 @@ def update(opts: Options) -> Package:
 
         if package.maven_deps:
             update_maven_deps_hash(opts, package.filename, package.maven_deps)
+
+        if package.mix_deps:
+            update_mix_deps_hash(opts, package.filename, package.mix_deps)
 
         if isinstance(package.cargo_lock, CargoLockInSource) or isinstance(
             package.cargo_lock, CargoLockInStore

--- a/tests/test_mix.py
+++ b/tests/test_mix.py
@@ -1,0 +1,27 @@
+import subprocess
+
+import conftest
+
+from nix_update.options import Options
+from nix_update.update import update
+
+
+def test_update(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs() as path:
+        opts = Options(attribute="mix", import_path=str(path))
+        update(opts)
+        mix_hash = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "mix.mixFodDeps.outputHash",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert mix_hash != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -16,4 +16,5 @@
   npm-package = pkgs.callPackage ./npm-package.nix { };
   pnpm = pkgs.callPackage ./pnpm.nix { };
   maven = pkgs.callPackage ./maven.nix { };
+  mix = pkgs.callPackage ./mix.nix { };
 }

--- a/tests/testpkgs/mix.nix
+++ b/tests/testpkgs/mix.nix
@@ -1,0 +1,18 @@
+{ beamPackages, fetchFromGitHub }:
+
+beamPackages.mixRelease rec {
+  pname = "credo-language-server";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "elixir-tools";
+    repo = "credo-language-server";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  mixFodDeps = beamPackages.fetchMixDeps {
+    inherit pname version src;
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+}


### PR DESCRIPTION
Happy to move things around, rename, document differently. This adds support for automatically updating the `mixFodDeps` hash used by `beamPackages.mixRelease`.

Thanks for the handy update script!