### PR TITLE
Try pkg.meta.position after unsafeGetAttrPos

### DIFF
--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -153,14 +153,14 @@ let
 
   raw_version_position = sanitizePosition (builtins.unsafeGetAttrPos "version" pkg);
 
-  position = if pkg ? meta.position then
-    sanitizePosition (positionFromMeta pkg)
-  else if pkg ? isRubyGem then
+  position = if pkg ? isRubyGem then
     raw_version_position
   else if pkg ? isPhpExtension then
     raw_version_position
+  else if (builtins.unsafeGetAttrPos "src" pkg) != null then
+    sanitizePosition (builtins.unsafeGetAttrPos "src" pkg)
   else
-    sanitizePosition (builtins.unsafeGetAttrPos "src" pkg);
+    sanitizePosition (positionFromMeta pkg);
 in {{
   name = pkg.name;
   old_version = pkg.version or (builtins.parseDrvName pkg.name).version;


### PR DESCRIPTION
`meta.position` is prone to point at files where `src` and `version` is not contained, as is the case for overridden packages and packages that use a generic builder.
There is also the fix explored in https://github.com/NixOS/nixpkgs/pull/329900 and https://github.com/NixOS/nixpkgs/pull/295973, which would alleviate many of the errors while creating new ones.

Fixes https://github.com/Mic92/nix-update/pull/247#issuecomment-2281135694