### PR TITLE
fix handling of cargo.lock outside a workspace

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -280,8 +280,6 @@ def generate_cargo_lock(opts: Options, filename: str) -> None:
     res = run(
         [
             "nix",
-            "--extra-experimental-features",
-            "flakes nix-command",
             "build",
             "-L",
             "--no-link",

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -308,7 +308,17 @@ def generate_cargo_lock(opts: Options, filename: str) -> None:
             cwd=tempdir,
         )
 
-        shutil.copy(tempdir + "/Cargo.lock", Path(filename).parent / "Cargo.lock")
+        if (
+            lockfile_in_subdir := Path(tempdir)
+            / opts.lockfile_metadata_path
+            / "Cargo.lock"
+        ).exists():
+            # if Cargo.toml is outside a workspace, Cargo.lock is generated in the same directory as Cargo.toml
+            lockfile = lockfile_in_subdir
+        else:
+            lockfile = Path(tempdir) / "Cargo.lock"
+
+        shutil.copy(lockfile, Path(filename).parent / "Cargo.lock")
 
 
 def update_composer_deps_hash(opts: Options, filename: str, current_hash: str) -> None:

--- a/tests/testpkgs/cargo-lock-generate/with-lockfile-metadata-path-outside-workspace/default.nix
+++ b/tests/testpkgs/cargo-lock-generate/with-lockfile-metadata-path-outside-workspace/default.nix
@@ -1,0 +1,23 @@
+{ python3Packages
+, rustPlatform
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "pylance";
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "lancedb";
+    repo = "lance";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  cargoDeps = rustPlatform.importCargoLock { lockFile = ./Cargo.lock; };
+}

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -5,6 +5,7 @@
   cargoLock.expand = pkgs.callPackage ./cargo-lock-expand { };
   cargoLock.generate.simple = pkgs.callPackage ./cargo-lock-generate/simple { };
   cargoLock.generate.with-lockfile-metadata-path = pkgs.callPackage ./cargo-lock-generate/with-lockfile-metadata-path { };
+  cargoLock.generate.with-lockfile-metadata-path-outside-workspace = pkgs.callPackage ./cargo-lock-generate/with-lockfile-metadata-path-outside-workspace { };
   cargoLock.update = pkgs.callPackage ./cargo-lock-update { };
   composer = pkgs.callPackage ./composer.nix { };
   crate = pkgs.callPackage ./crate.nix { };


### PR DESCRIPTION
This is a follow-up PR for https://github.com/Mic92/nix-update/pull/266.

If Cargo.toml is outside a workspace, Cargo.lock is generated in the same directory as Cargo.toml.

The current implementation expects Cargo.lock to be in the project root, so the update fails.
`FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpn_dgfq0d/Cargo.lock'`