### PR TITLE
Add --update-script-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ $ nix-update sbt --version=unstable
 Update 1.4.6 -> 1.5.0-M1 in sbt
 ```
 
+Nix-update can also run the `passthru.updateScript` defined by the package.
+
+```console
+$ nix-update sbt --use-update-script
+```
+
+Arguments can be passed to `nix-shell maintainers/scripts/update.nix` like so
+
+```console
+$ nix-update sbt --use-update-script --update-script-args "--argstr skip-prompt true"
+```
+
 ## Development setup
 
 First clone the repo to your preferred location (in the following, we assume `~/` - your home):

--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import shlex
 import shutil
 import sys
 import tempfile
@@ -40,6 +41,12 @@ def parse_args(args: list[str]) -> Options:
         "--use-update-script",
         action="store_true",
         help="Use passthru.updateScript instead if possible",
+    )
+    parser.add_argument(
+        "--update-script-args",
+        default=[],
+        type=shlex.split,
+        help="Args to pass to `nix-shell maintainers/scripts/update.nix`, subject to splitting.",
     )
     parser.add_argument(
         "--url",
@@ -108,6 +115,7 @@ def parse_args(args: list[str]) -> Options:
         build=a.build,
         commit=a.commit,
         use_update_script=a.use_update_script,
+        update_script_args=a.update_script_args,
         url=a.url,
         write_commit_message=a.write_commit_message,
         run=a.run,

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -17,6 +17,7 @@ class Options:
     url: str | None = None
     commit: bool = False
     use_update_script: bool = False
+    update_script_args: list[str] = field(default_factory=list)
     write_commit_message: str | None = None
     shell: bool = False
     run: bool = False

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -433,6 +433,7 @@ def update(opts: Options) -> Package:
                 "--argstr",
                 "package",
                 opts.attribute,
+                *opts.update_script_args,
             ],
             stdout=None,
         )


### PR DESCRIPTION
This allows you to skip the prompt when using `-u`, nice to have when scripting `nix-update`

```
nix-update sbt --use-update-script --update-script-args "--argstr skip-prompt true"
```