### PR TITLE
Fix updating all matching version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,6 @@ nix-update might not work correctly if a file contain multiple packages as it
 performs naive search and replace to update version numbers. This might be a
 problem if:
 
-- A file contains the same version string for multiple packages.
 - `name` is used instead of `pname` and/or `${version}` is injected into `name`.
 
 Related discussions:

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -35,11 +35,23 @@ def replace_version(package: Package) -> bool:
 
     if changed:
         info(f"Update {old_version} -> {new_version} in {package.filename}")
+        version_string_in_version_declaration = False
+        if package.version_position is not None:
+            with open(package.filename) as f:
+                for i, line in enumerate(f, 1):
+                    if package.version_position.line == i:
+                        version_string_in_version_declaration = old_version in line
+                        break
         with fileinput.FileInput(package.filename, inplace=True) as f:
-            for line in f:
+            for i, line in enumerate(f, 1):
                 if package.new_version.rev:
                     line = line.replace(package.rev, package.new_version.rev)
-                print(line.replace(f'"{old_version}"', f'"{new_version}"'), end="")
+                if (
+                    not version_string_in_version_declaration
+                    or package.version_position.line == i
+                ):
+                    line = line.replace(f'"{old_version}"', f'"{new_version}"')
+                print(line, end="")
     else:
         info(f"Not updating version, already {old_version}")
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,91 @@
+import os
+import subprocess
+
+import conftest
+import pytest
+
+from nix_update import main
+
+
+@pytest.mark.skipif(
+    "GITHUB_TOKEN" not in os.environ, reason="No GITHUB_TOKEN environment variable set"
+)
+def test_multiple_sources(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(["--file", str(path), "--commit", "set.fd"])
+        fd_version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "set.fd.version",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        skim_version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "set.skim.version",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert tuple(map(int, fd_version.split("."))) >= (4, 4, 3)
+        assert tuple(map(int, skim_version.split("."))) == (0, 0, 0)
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(commit)
+        assert fd_version in commit
+        assert "sharkdp/fd/compare/v0.0.0..." in commit
+        assert "skim" not in commit
+
+
+@pytest.mark.skipif(
+    "GITHUB_TOKEN" not in os.environ, reason="No GITHUB_TOKEN environment variable set"
+)
+def test_let_bound_version(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(["--file", str(path), "--commit", "let-bound-version"])
+        version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "let-bound-version.version",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) >= (8, 5, 2)
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(commit)
+        assert version in commit
+        assert "github" in commit
+        assert "https://github.com/sharkdp/fd/compare/v8.0.0...v" in commit

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -30,4 +30,6 @@
   pnpm = pkgs.callPackage ./pnpm.nix { };
   maven = pkgs.callPackage ./maven.nix { };
   mix = pkgs.callPackage ./mix.nix { };
+  set = pkgs.callPackage ./set.nix { };
+  let-bound-version = pkgs.callPackage ./let-bound-version.nix { };
 }

--- a/tests/testpkgs/let-bound-version.nix
+++ b/tests/testpkgs/let-bound-version.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchFromGitHub }:
+
+let
+  version = "8.0.0";
+in
+stdenv.mkDerivation rec {
+  pname = "fd";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "sharkdp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+}

--- a/tests/testpkgs/set.nix
+++ b/tests/testpkgs/set.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+{
+  fd = stdenv.mkDerivation rec {
+    pname = "fd";
+    version = "0.0.0";
+
+    src = fetchFromGitHub {
+      owner = "sharkdp";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+  };
+
+  skim = stdenv.mkDerivation rec {
+    pname = "skim";
+    version = "0.0.0";
+
+    src = fetchFromGitHub {
+      owner = "skim-rs";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+  };
+}


### PR DESCRIPTION
Prior to this change, nix-update would update all version strings which were equal to the specified package to update. Now, only the version line of the specified package will be updated.