### PR TITLE
fix: use `shlex.join` for command formatting in run function

### DIFF
--- a/nix_update/utils.py
+++ b/nix_update/utils.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 import sys
 from collections.abc import Callable
@@ -31,7 +32,7 @@ def run(
     check: bool = True,
     extra_env: dict[str, str] = {},
 ) -> "subprocess.CompletedProcess[str]":
-    info("$ " + " ".join(command))
+    info("$ " + shlex.join(command))
     env = os.environ.copy()
     env.update(extra_env)
     return subprocess.run(


### PR DESCRIPTION
current command output is not very nice when some argument contains space, for example: `$ git -C /export/nvme-512g/src/nixpkgs commit --verbose --message rtorrent: 0.10.0-unstable-2024-12-06 -> 0.10.0-unstable-2024-12-08 /export/nvme-512g/src/nixpkgs/pkgs/by-name/rt/rtorrent/package.nix`