### PR TITLE
feat: add `--subpackage` option to update multiple derivations

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -107,6 +107,13 @@ def parse_args(args: list[str]) -> Options:
         help="Path to the directory containing the metadata (e.g. Cargo.toml) referenced by the lockfile",
         default=".",
     )
+    parser.add_argument(
+        "-s",
+        "--subpackage",
+        action="append",
+        help="Attribute of a subpackage that nix-update should try to update hashes for",
+        default=None,
+    )
 
     a = parser.parse_args(args)
     return Options(
@@ -116,6 +123,7 @@ def parse_args(args: list[str]) -> Options:
         commit=a.commit,
         use_update_script=a.use_update_script,
         update_script_args=a.update_script_args,
+        subpackages=a.subpackage,
         url=a.url,
         write_commit_message=a.write_commit_message,
         run=a.run,

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -13,6 +13,7 @@ class Options:
     version_preference: VersionPreference = VersionPreference.STABLE
     version_regex: str = "(.*)"
     import_path: str = os.getcwd()
+    subpackages: list[str] | None = None
     override_filename: str | None = None
     url: str | None = None
     commit: bool = False

--- a/tests/test_subpackage.py
+++ b/tests/test_subpackage.py
@@ -1,0 +1,42 @@
+import subprocess
+
+import conftest
+
+from nix_update.options import Options
+from nix_update.update import update
+
+
+def test_update(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs() as path:
+        opts = Options(
+            attribute="subpackage", subpackages=["autobrr-web"], import_path=str(path)
+        )
+        update(opts)
+
+        def get_attr(attr: str) -> str:
+            return subprocess.run(
+                [
+                    "nix",
+                    "eval",
+                    "--raw",
+                    "--extra-experimental-features",
+                    "nix-command",
+                    "-f",
+                    path,
+                    attr,
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+            ).stdout.strip()
+
+        subpackage_hash = get_attr("subpackage.autobrr-web.pnpmDeps.outputHash")
+        assert subpackage_hash != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+        src_hash = get_attr("subpackage.src.outputHash")
+        assert src_hash != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+        gomodules_hash = get_attr("subpackage.goModules.outputHash")
+        assert gomodules_hash != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+        version = get_attr("subpackage.version")
+        assert tuple(map(int, version.split("."))) >= (1, 53, 0)

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -33,4 +33,5 @@
   mix = pkgs.callPackage ./mix.nix { };
   set = pkgs.callPackage ./set.nix { };
   let-bound-version = pkgs.callPackage ./let-bound-version.nix { };
+  subpackage = pkgs.callPackage ./subpackage.nix { };
 }

--- a/tests/testpkgs/subpackage.nix
+++ b/tests/testpkgs/subpackage.nix
@@ -1,0 +1,64 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nodejs,
+  pnpm_9,
+  typescript,
+}:
+
+let
+  pname = "autobrr";
+  version = "1.53.0";
+  src = fetchFromGitHub {
+    owner = "autobrr";
+    repo = "autobrr";
+    rev = "v${version}";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  autobrr-web = stdenvNoCC.mkDerivation {
+    pname = "${pname}-web";
+    inherit src version;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_9.configHook
+      typescript
+    ];
+
+    sourceRoot = "${src.name}/web";
+
+    pnpmDeps = pnpm_9.fetchDeps {
+      inherit (autobrr-web)
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+
+    postBuild = ''
+      pnpm run build
+    '';
+
+    installPhase = ''
+      cp -r dist $out
+    '';
+  };
+in
+buildGoModule rec {
+  inherit
+    autobrr-web
+    pname
+    version
+    src
+    ;
+
+  vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  preBuild = ''
+    cp -r ${autobrr-web}/* web/dist
+  '';
+}


### PR DESCRIPTION
Adds an option for users to specify subpackages that `nix-update` should also look at. `nix-update` will evaluate these sub-derivations after updating the package's version and source, but before trying to evaluate the package's main derivation. This allows for subpackages that are depended upon by the main package build.

Not included is any sort of accommodation for sub-subpackages. I hope those do not occur often in real builds.

Closes #310.