### PR TITLE
fix `fetchurl` with `--version-regex`

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -46,7 +46,7 @@ def replace_version(package: Package) -> bool:
                         break
         with fileinput.FileInput(package.filename, inplace=True) as f:
             for i, line in enumerate(f, 1):
-                if package.new_version.rev:
+                if package.rev is not None and package.new_version.rev:
                     line = line.replace(old_rev_tag, package.new_version.rev)
                 if (
                     not version_string_in_version_declaration

--- a/tests/test_version_regex_no_rev.py
+++ b/tests/test_version_regex_no_rev.py
@@ -1,0 +1,40 @@
+import subprocess
+
+import conftest
+
+from pathlib import Path
+from nix_update import main
+
+def test_main(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(["--file", str(path), "--commit", "net-news-wire", "--version-regex", "^mac-(\\d+\\.\\d+\\.\\d+)$"])
+        version = get_nix_value(path, "net-news-wire.version")
+        src = get_nix_value(path, "net-news-wire.src")
+        commit = subprocess.run(
+            ["git", "-C", path, "show"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(commit)
+        assert src != "/nix/store/8k7nkbk4xbxwc6zc2bp85i8pvbvzzx6a-NetNewsWire6.1.5.zip"
+        assert version != "6.1.5"
+        assert version in commit
+        assert "net-news-wire: 6.1.5 ->" in commit
+
+def get_nix_value(path: Path, key: str) -> str:
+    return subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--raw",
+            "--extra-experimental-features",
+            "nix-command",
+            "-f",
+            path,
+            key,
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -26,6 +26,7 @@
   pypi = pkgs.python3.pkgs.callPackage ./pypi.nix { };
   sourcehut = pkgs.python3.pkgs.callPackage ./sourcehut.nix { };
   savanna = pkgs.python3.pkgs.callPackage ./savanna.nix { };
+  net-news-wire = pkgs.callPackage ./net-news-wire.nix { };
   npm = pkgs.callPackage ./npm.nix { };
   npm-package = pkgs.callPackage ./npm-package.nix { };
   npm-lock-generate = pkgs.callPackage ./npm-lock-generate { };

--- a/tests/testpkgs/net-news-wire.nix
+++ b/tests/testpkgs/net-news-wire.nix
@@ -1,0 +1,15 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "net-news-wire";
+  version = "6.1.5";
+
+  src = fetchurl {
+    url = "https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-${version}/NetNewsWire${version}.zip";
+    hash = "sha256-92hsVSEpa661qhebeSd5lxt8MtIJRn7YZyKlMs0vle0=";
+  };
+}


### PR DESCRIPTION
When using `--version-regex` on a package the fetches source via `fetchurl` the update failed because `package.rev` was `None`