### PR TITLE
feat: add --src-only flag

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -116,6 +116,11 @@ def parse_args(args: list[str]) -> Options:
         default=None,
     )
     parser.add_argument(
+        "--src-only",
+        help="Only update the source, not dependencies such as npmDeps, cargoDeps or nugetDeps",
+        action="store_true",
+    )
+    parser.add_argument(
         "--option",
         help="Nix option to set",
         action="append",
@@ -154,6 +159,7 @@ def parse_args(args: list[str]) -> Options:
         system=a.system,
         generate_lockfile=a.generate_lockfile,
         lockfile_metadata_path=a.lockfile_metadata_path,
+        src_only=a.src_only,
         extra_flags=extra_flags,
     )
 

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -29,6 +29,7 @@ class Options:
     system: str | None = None
     generate_lockfile: bool = False
     lockfile_metadata_path: str = "."
+    src_only: bool = False
     extra_flags: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -527,8 +527,8 @@ def update(opts: Options) -> Package:
             subpackage_opts.version_preference = VersionPreference.SKIP
             update(subpackage_opts)
 
-    # if no package.hash was provided we just update the other hashes unconditionally
-    if update_hash or not package.hash:
+    # if no package.hash was provided we just update the other hashes unless it should be skipped
+    if (update_hash or not package.hash) and not opts.src_only:
         if package.go_modules:
             update_go_modules_hash(opts, package.filename, package.go_modules)
 

--- a/tests/test_src_only.py
+++ b/tests/test_src_only.py
@@ -1,0 +1,48 @@
+import json
+import subprocess
+
+import conftest
+
+from nix_update import main
+
+
+def test_update(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(
+            [
+                "--file",
+                str(path),
+                "--commit",
+                "nuget-deps-generate",
+                "--version",
+                "v1.1.1",
+                "--src-only",
+            ]
+        )
+
+        nuget_deps_raw = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--json",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "nuget-deps-generate.nugetDeps",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        nuget_deps = json.loads(nuget_deps_raw)
+        assert len(nuget_deps) == 0
+
+        diff = subprocess.run(
+            ["git", "-C", path, "log"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(diff)
+        assert "https://github.com/ExOK/Celeste64/compare/v1.1.0...v1.1.1" in diff


### PR DESCRIPTION
Context: last few comments in https://github.com/Mic92/nix-update/pull/320 (this flag was initially mentioned as `--skip-deps`,  `--dont-update-deps` or `--no-fetch-deps` that would've only applied to `nugetDeps`)

In some cases you want to use nix-update's logic where it can fetch the latest version and hash from various sources, but don't want to update dependencies like `nugetDeps`, `npmDeps`, `cargoDeps`, etc. Currently the solution for this in nixpkgs is making a request to the GitHub API or other sources, and using `update-source-version` to update the version, then manually do the deps update part.

Instead of writing 
```bash
new_version="$(curl -s "https://api.github.com/repos/AvaloniaUI/Avalonia/releases/latest" | jq --raw-output '.tag_name')"
update-source-version avalonia "$new_version"
# operations that need to be ran before updating deps would go here
"$(nix-build -A "$package".fetch-deps --no-out-link)"
```
You can do
```bash
nix-update avalonia --src-only
# operations that need to be ran before updating deps would go here
"$(nix-build -A "$package".fetch-deps --no-out-link)"
```

cc @Mic92 @corngood @GGG-Killer
