### PR TITLE
fix typo in code

### DIFF
--- a/nix_update/version/rubygems.py
+++ b/nix_update/version/rubygems.py
@@ -28,5 +28,5 @@ def fetch_rubygem_versions(url: ParseResult) -> list[Version]:
         assert isinstance(number, str)
         prerelease = version["prerelease"]
         assert isinstance(prerelease, bool)
-        version.append(Version(number, prerelease=prerelease))
+        versions.append(Version(number, prerelease=prerelease))
     return versions


### PR DESCRIPTION
```
} --extra-experimental-features flakes nix-command
fetch https://rubygems.org/api/v1/versions/bundler.json
Traceback (most recent call last):
  File "/nix/store/2dk7xil4ing93997lx1y4rgda5s2zmwv-nix-update-1.7.0/bin/.nix-update-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/2dk7xil4ing93997lx1y4rgda5s2zmwv-nix-update-1.7.0/lib/python3.12/site-packages/nix_update/__init__.py", line 311, in main
    package = update(options)
              ^^^^^^^^^^^^^^^
  File "/nix/store/2dk7xil4ing93997lx1y4rgda5s2zmwv-nix-update-1.7.0/lib/python3.12/site-packages/nix_update/update.py", line 463, in update
    update_hash = update_version(
                  ^^^^^^^^^^^^^^^
  File "/nix/store/2dk7xil4ing93997lx1y4rgda5s2zmwv-nix-update-1.7.0/lib/python3.12/site-packages/nix_update/update.py", line 397, in update_version
    new_version = fetch_latest_version(
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/2dk7xil4ing93997lx1y4rgda5s2zmwv-nix-update-1.7.0/lib/python3.12/site-packages/nix_update/version/__init__.py", line 93, in fetch_latest_version
    versions = fetcher(url)
               ^^^^^^^^^^^^
  File "/nix/store/2dk7xil4ing93997lx1y4rgda5s2zmwv-nix-update-1.7.0/lib/python3.12/site-packages/nix_update/version/rubygems.py", line 29, in fetch_rubygem_versions
    version.append(Version(number, prerelease=prerelease))
    ^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'append'
```