### PR TITLE
Support --use-update-script with flake packages

### DIFF
--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -40,6 +40,7 @@ class Package:
     attribute: str
     import_path: InitVar[str]
     name: str
+    pname: str
     old_version: str
     filename: str
     line: int
@@ -144,9 +145,7 @@ def eval_expression(
           sanitizePosition = x: x;
         """
 
-    has_update_script = (
-        "false" if flake else "pkg.passthru.updateScript or null != null"
-    )
+    has_update_script = "pkg.passthru.updateScript or null != null"
 
     return f"""
 let
@@ -170,6 +169,7 @@ let
     sanitizePosition (positionFromMeta pkg);
 in {{
   name = pkg.name;
+  pname = pkg.pname;
   old_version = pkg.version or (builtins.parseDrvName pkg.name).version;
   inherit raw_version_position;
   filename = position.file;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,8 @@ class Helpers:
     @staticmethod
     @contextmanager
     def testpkgs(init_git: bool = False) -> Iterator[Path]:
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory() as _tmpdirname:
+            tmpdirname = Path(_tmpdirname)
             shutil.copytree(
                 Helpers.root().joinpath("testpkgs"), tmpdirname, dirs_exist_ok=True
             )

--- a/tests/test_flake.py
+++ b/tests/test_flake.py
@@ -40,3 +40,40 @@ def test_main(helpers: conftest.Helpers) -> None:
         ).stdout.strip()
         print(diff)
         assert "https://diff.rs/fd-find/8.0.0/10.2.0" in diff
+
+
+def test_update_script(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(
+            [
+                "--file",
+                str(path),
+                "--flake",
+                "--commit",
+                "--test",
+                "--use-update-script",
+                "crate",
+            ]
+        )
+        version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "flakes nix-command",
+                f"{path}#crate.version",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) >= (8, 5, 2)
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(commit)
+        assert f"crate: 8.0.0 -> {version}" in commit

--- a/tests/testpkgs/crate.nix
+++ b/tests/testpkgs/crate.nix
@@ -2,6 +2,7 @@
   rustPlatform,
   fetchCrate,
   hello,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "fd-find";
@@ -17,5 +18,11 @@ rustPlatform.buildRustPackage rec {
   passthru.tests = {
     foo = hello;
     bar = hello;
+  };
+  passthru.updateScript = nix-update-script {
+    attrPath = "crate";
+    extraArgs = [
+      "--flake"
+    ];
   };
 }


### PR DESCRIPTION
1. like the title says, I made it possible to use `--use-update-script` with flake packages. However, I've never used that flag outside of my personal use so I'm really unsure if I implemented correctly
2. Added `--commit-message` flag to print the commit message to stdout
3. Added `--quiet` flag to suppress logs of subprocesses and stuff