### PR TITLE
Improve diff url with github

### DIFF
--- a/tests/test_cargo_lock_generate.py
+++ b/tests/test_cargo_lock_generate.py
@@ -83,7 +83,8 @@ def test_with_lockfile_metadata_path(helpers: conftest.Helpers) -> None:
         ).stdout.strip()
         print(diff)
         assert (
-            "https://github.com/lancedb/lancedb/compare/python-v0.11.0...0.12.0" in diff
+            "https://github.com/lancedb/lancedb/compare/python-v0.11.0...python-v0.12.0"
+            in diff
         )
 
 

--- a/tests/test_cargo_vendor_deps.py
+++ b/tests/test_cargo_vendor_deps.py
@@ -78,4 +78,4 @@ def test_non_rust_package(helpers: conftest.Helpers) -> None:
             check=True,
         ).stdout.strip()
         print(diff)
-        assert "https://github.com/pop-os/popsicle/compare/1.3.0...v1.3.3" in diff
+        assert "https://github.com/pop-os/popsicle/compare/1.3.0...1.3.3" in diff

--- a/tests/test_fetchurl_github_release.py
+++ b/tests/test_fetchurl_github_release.py
@@ -1,0 +1,77 @@
+import os
+import subprocess
+
+import conftest
+import pytest
+
+from nix_update import main
+
+
+@pytest.mark.skipif(
+    "GITHUB_TOKEN" not in os.environ, reason="No GITHUB_TOKEN environment variable set"
+)
+def test_fixed_version_no_prefix(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(
+            [
+                "--file",
+                str(path),
+                "--commit",
+                "--version",
+                "5.1.0",
+                "fetchurl-github-release",
+            ]
+        )
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        assert "https://github.com/vrana/adminer/compare/v5.0.5...v5.1.0" in commit
+
+
+@pytest.mark.skipif(
+    "GITHUB_TOKEN" not in os.environ, reason="No GITHUB_TOKEN environment variable set"
+)
+def test_fixed_version_yes_prefix(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(
+            [
+                "--file",
+                str(path),
+                "--commit",
+                "--version",
+                "v5.1.0",
+                "fetchurl-github-release",
+            ]
+        )
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        assert "https://github.com/vrana/adminer/compare/v5.0.5...v5.1.0" in commit
+
+
+@pytest.mark.skipif(
+    "GITHUB_TOKEN" not in os.environ, reason="No GITHUB_TOKEN environment variable set"
+)
+def test_auto_version(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(
+            [
+                "--file",
+                str(path),
+                "--commit",
+                "fetchurl-github-release",
+            ]
+        )
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        assert "https://github.com/vrana/adminer/compare/v5.0.5...v" in commit

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -18,6 +18,7 @@
   cargoVendorDeps.rustPackage = pkgs.callPackage ./cargo-vendor-deps/rust-package.nix { };
   composer-old = pkgs.callPackage ./composer-old.nix { };
   crate = pkgs.callPackage ./crate.nix { };
+  fetchurl-github-release = pkgs.callPackage ./fetchurl-github-release.nix { };
   nuget-deps-generate = pkgs.callPackage ./nuget-deps-generate { };
   gitea = pkgs.callPackage ./gitea.nix { };
   github = pkgs.callPackage ./github.nix { };

--- a/tests/testpkgs/fetchurl-github-release.nix
+++ b/tests/testpkgs/fetchurl-github-release.nix
@@ -1,0 +1,14 @@
+{
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  version = "5.0.5";
+  pname = "adminer";
+
+  src = fetchurl {
+    url = "https://github.com/vrana/adminer/releases/download/v${finalAttrs.version}/adminer-${finalAttrs.version}.zip";
+    hash = "sha256-7VAy9bE9dUZpkKtRMUa/boA6NlfZ7tBT/2x1POtazoM=";
+  };
+})


### PR DESCRIPTION
The diff link in the generated commit message was broken in some cases, most notably containing `None`, missing/adding extra `v` as a version prefix.

Fixes https://github.com/NixOS/nixpkgs/issues/394072
- when there was a github link, previously it expected `fetchFromGitHub`, so it tried to read `src.rev` or  `src.tag` which doesn't exist when using plain `fetchurl`
- when the user specifies a fixed version, eg. `--version 11.41` (without a version prefix), it expected that the the tag/rev is called exactly that, but it can be `v11.41` or with other prefix

The solution is rather hacky and it's limited to github, there are multiple factors that make it hard to implement correctly:
- unclear division between user provided version, version got from eval, version got from fetching
- inconsistent naming: `package`/`version` are used interchangably, `new`/`old`/no-prefix is inconsistent, `version_number` containing more than numbers
- heuristics like [stripping "v" version prefix](https://github.com/gepbird/nix-update/blob/2eaf862d4eb4b119362379ce9c23e1c5478b4113/nix_update/update.py#L31-L32)...

In a few weeks/months when I'll have more time, I'd be happy to do a bigger refactor in this area, is it okay with you @Mic92?