### PR TITLE
support multiple capture groups in version-regex

### DIFF
--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -77,13 +77,15 @@ def extract_version(version: Version, version_regex: str) -> Version | None:
     pattern = re.compile(version_regex)
     match = re.match(pattern, version.number)
     if match is not None:
-        group = match.group(1)
-        if group is not None:
+        # Filter non-matched groups which come back as None.
+        groups = [g for g in match.groups() if g]
+        if len(groups) > 0:
+            number = ".".join(groups)
             return Version(
-                group,
+                number,
                 prerelease=version.prerelease,
                 rev=version.rev
-                or (None if version.number == group else version.number),
+                or (None if version.number == number else version.number),
             )
     return None
 

--- a/tests/test_version_regex_no_rev.py
+++ b/tests/test_version_regex_no_rev.py
@@ -32,6 +32,25 @@ def test_main(helpers: conftest.Helpers) -> None:
         assert "net-news-wire: 6.1.5 ->" in commit
 
 
+def test_groups(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(
+            [
+                "--file",
+                str(path),
+                "postgresql",
+                "--version-regex",
+                "^REL_(\\d+)_(\\d+)(?:_(\\d+))?$",
+            ],
+        )
+        version = get_nix_value(path, "postgresql.version")
+        print(version)
+        assert version != "17.0"
+        assert version != "17."
+        assert version != "17"
+        assert "17." in version
+
+
 def get_nix_value(path: Path, key: str) -> str:
     return subprocess.run(
         [

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -41,4 +41,5 @@
   set = pkgs.callPackage ./set.nix { };
   let-bound-version = pkgs.callPackage ./let-bound-version.nix { };
   subpackage = pkgs.callPackage ./subpackage.nix { };
+  postgresql = pkgs.callPackage ./postgresql.nix { };
 }

--- a/tests/testpkgs/postgresql.nix
+++ b/tests/testpkgs/postgresql.nix
@@ -1,0 +1,13 @@
+{ fetchFromGitHub, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "postgresql";
+  version = "17.0";
+
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    tag = "REL_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+}


### PR DESCRIPTION
This supports multiple capture groups in the `--version-regex` option. The groups will be concatenated to a single version delimited by `.`. This allows extracting versions from versioning schemes such as PostgreSQL's, which use `REL_17_0` tags etc., i.e. they use a different separator.