### PR TITLE
Fix wrong URL being fetched for npm's scoped package

### DIFF
--- a/nix_update/version/npm.py
+++ b/nix_update/version/npm.py
@@ -11,7 +11,8 @@ def fetch_npm_versions(url: ParseResult) -> list[Version]:
     if url.netloc != "registry.npmjs.org":
         return []
     parts = url.path.split("/")
-    package = parts[1]
+    # Handle scoped packages like @myorg/mypackage
+    package = f"{parts[1]}/{parts[2]}" if parts[1].startswith("@") else parts[1]
     npm_url = f"https://registry.npmjs.org/{package}/latest"
     info(f"fetch {npm_url}")
     resp = urllib.request.urlopen(npm_url)

--- a/tests/test_npm_fetch_latest_version.py
+++ b/tests/test_npm_fetch_latest_version.py
@@ -1,0 +1,45 @@
+import io
+import unittest.mock
+from urllib.parse import urlparse
+
+from nix_update.version import fetch_latest_version
+from nix_update.version.version import VersionPreference
+from tests import conftest
+
+
+def fake_npm_urlopen(url: str) -> io.BytesIO:
+    if url == "https://registry.npmjs.org/@anthropic-ai/claude-code/latest":
+        return io.BytesIO(b'{"version": "1.0.43"}')
+
+    if url == "https://registry.npmjs.org/express/latest":
+        return io.BytesIO(b'{"version": "4.21.2"}')
+
+    raise ValueError(f"Unexpected URL in test: {url}")  # noqa: EM102, TRY003
+
+
+def test_scoped_npm(helpers: conftest.Helpers) -> None:
+    del helpers
+    with unittest.mock.patch("urllib.request.urlopen", fake_npm_urlopen):
+        assert (
+            fetch_latest_version(
+                urlparse(
+                    "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.42.tgz",
+                ),
+                VersionPreference.STABLE,
+                "(.*)",
+            ).number
+            == "1.0.43"
+        )
+
+
+def test_regular_npm(helpers: conftest.Helpers) -> None:
+    del helpers
+    with unittest.mock.patch("urllib.request.urlopen", fake_npm_urlopen):
+        assert (
+            fetch_latest_version(
+                urlparse("https://registry.npmjs.org/express/-/express-4.21.1.tgz"),
+                VersionPreference.STABLE,
+                "(.*)",
+            ).number
+            == "4.21.2"
+        )


### PR DESCRIPTION
If derivation's src is from a npm package and if such npm package is scoped (e.g. `@org/packagename` instead of `packagename`), wrong URL would be used to fetch latest version and failed.

To reproduce:

```sh
> cat test-scoped-npm.nix
{
  pkgs ? import <nixpkgs> { },
}:
{
  claude-code = pkgs.stdenv.mkDerivation rec {
    pname = "claude-code";
    version = "1.0.42";

    src = pkgs.fetchurl {
      url =
"https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
      sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
    };
  };
}
> ./bin/nix-update --file test-scoped-npm.nix claude-code
# OMITTED
fetch https://registry.npmjs.org/@anthropic-ai/latest
Traceback (most recent call last):
  File "/Users/limouren/nix-update/./bin/nix-update", line 12, in <module>
    main()
    ~~~~^^
  File "/Users/limouren/nix-update/nix_update/__init__.py", line 387, in main
    package = update(options)
  File "/Users/limouren/nix-update/nix_update/update.py", line 604, in update
    update_hash = update_version(
        opts,
    ...<3 lines>...
        opts.version_regex,
    )
  File "/Users/limouren/nix-update/nix_update/update.py", line 460, in update_version
    new_version = fetch_latest_version(
        package.parsed_url,
    ...<4 lines>...
        version_prefix,
    )
  File "/Users/limouren/nix-update/nix_update/version/__init__.py", line 102, in fetch_latest_version
    versions = fetcher(url)
  File "/Users/limouren/nix-update/nix_update/version/npm.py", line 17, in fetch_npm_versions
    resp = urllib.request.urlopen(npm_url)
  File "/nix/store/j1spz18w5a10r9nj4wpkyh0cx730rs4z-python3-3.13.4/lib/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/j1spz18w5a10r9nj4wpkyh0cx730rs4z-python3-3.13.4/lib/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/nix/store/j1spz18w5a10r9nj4wpkyh0cx730rs4z-python3-3.13.4/lib/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/nix/store/j1spz18w5a10r9nj4wpkyh0cx730rs4z-python3-3.13.4/lib/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/nix/store/j1spz18w5a10r9nj4wpkyh0cx730rs4z-python3-3.13.4/lib/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/nix/store/j1spz18w5a10r9nj4wpkyh0cx730rs4z-python3-3.13.4/lib/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```

Note that the log shows nix-update tries to fetch the URL:

* https://registry.npmjs.org/@anthropic-ai/latest

While the correct URL should be:

* https://registry.npmjs.org/@anthropic-ai/claude-code/latest

---

This PR fixes this and added two test cases to test for URL generation for both scoped and non-scoped packages.
