### PR TITLE
test: add nuget-deps-generate assert for deps.json being comitted

### DIFF
--- a/tests/test_nuget_deps_generate.py
+++ b/tests/test_nuget_deps_generate.py
@@ -37,10 +37,11 @@ def test_update(helpers: conftest.Helpers) -> None:
         assert len(nuget_deps) > 0
 
         diff = subprocess.run(
-            ["git", "-C", path, "log"],
+            ["git", "-C", path, "show"],
             text=True,
             stdout=subprocess.PIPE,
             check=True,
         ).stdout.strip()
         print(diff)
         assert "https://github.com/ExOK/Celeste64/compare/v1.1.0...v1.1.1" in diff
+        assert "a/nuget-deps-generate/deps.json" in diff


### PR DESCRIPTION
When updating dotnet packages, I used for example `nix-shell maintainers/scripts/update.nix --argstr package osu-lazer --argstr commit true` with an alias which works well.

Trying to replicate the same with `nix-update -u --commit osu-lazer` won't exactly work, it will leave the changed `deps.json` file uncomitted, this is what I'd like to fix, in this PR I only added a test for it.

`nix-update` currently detects changed files "manually" for each package, for example when updating the `chit` rust package that has `cargoLock.lockFile = ./Cargo.lock`, that path can be queried with `nix eval -f . chit.cargoDeps.lockFile` => `/home/gep/nixpkgs/pkgs/by-name/ch/chit/Cargo.lock`.
However for dotnet I couldn't find a similar function: in the `osu-lazer` dotnet package that has `nugetDeps = ./deps.json`, we can query the deps converted to a list of derivations by `nix eval -f . osu-lazer.nugetDeps` => `[ «derivation /nix/store/4nll8qs6g0kh8nr6zid601w2wqm43svn-AutoMapper-13.0.1.drv» ... ]`. cc @corngood @GGG-KILLER is there a way to query the file path that was given in `nugetDeps`? If not, would it be difficult to add?

Alternative solution is basically doing a `git add .` in `nix-update`, but this may commit other files the user has changed, or temporarily log files that was generated, etc. I haven't really checked what unrelated things it might commit, but I'd like to avoid this.