### PR TITLE
github.py: fix removal of .git suffix from repo

### DIFF
--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -16,11 +16,11 @@ from .version import Version
 
 # https://github.com/NixOS/nixpkgs/blob/13ae608185b2430ebffc8b181fa9a854cd241007/pkgs/build-support/fetchgithub/default.nix#L133-L143
 GITHUB_PUBLIC = re.compile(
-    r"^/(?P<owner>[^~/]+)/(?P<repo>[^/]+)(.git)?/archive/(?P<revWithTag>.+).tar.gz$",
+    r"^/(?P<owner>[^~]+?)/(?P<repo>.+?)(\.git)?/archive/(?P<revWithTag>.+).tar.gz$",
 )
-GITHUB_PUBLIC_GENERAL = re.compile(r"^/(?P<owner>[^/~]+)/(?P<repo>[^/]+)(.git)?")
+GITHUB_PUBLIC_GENERAL = re.compile(r"^/(?P<owner>[^~]+?)/(?P<repo>.+?)(\.git)?(/|$)")
 GITHUB_PRIVATE = re.compile(
-    r"^(/api/v3)?/repos/(?P<owner>[^/~]+)/(?P<repo>[^/]+)/tarball/(?P<revWithTag>.+)$",
+    r"^(/api/v3)?/repos/(?P<owner>[^~]+?)/(?P<repo>.+?)/tarball/(?P<revWithTag>.+)$",
 )
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -239,3 +239,34 @@ def test_github_fetchtree_private(helpers: conftest.Helpers) -> None:
         print(commit)
         assert version in commit
         assert "github" in commit
+
+
+def test_github_forcefetchgit(helpers: conftest.Helpers) -> None:
+    with helpers.testpkgs(init_git=True) as path:
+        main(["--file", str(path), "--commit", "github-forcefetchgit"])
+        version = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                path,
+                "github-forcefetchgit.version",
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert tuple(map(int, version.split("."))) >= (8, 5, 2)
+        commit = subprocess.run(
+            ["git", "-C", path, "log", "-1"],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        print(commit)
+        assert version in commit
+        assert "github" in commit
+        assert "https://github.com/sharkdp/fd/compare/v8.0.0...v" in commit

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -26,6 +26,7 @@
   github-tag = pkgs.callPackage ./github-tag.nix { };
   github-fetchtree = pkgs.callPackage ./github-fetchtree.nix { };
   github-fetchtree-private = pkgs.callPackage ./github-fetchtree-private.nix { };
+  github-forcefetchgit = pkgs.callPackage ./github-forcefetchgit.nix { };
   gitlab = pkgs.callPackage ./gitlab.nix { };
   pypi = pkgs.python3.pkgs.callPackage ./pypi.nix { };
   sourcehut = pkgs.python3.pkgs.callPackage ./sourcehut.nix { };

--- a/tests/testpkgs/github-forcefetchgit.nix
+++ b/tests/testpkgs/github-forcefetchgit.nix
@@ -1,0 +1,14 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "fd";
+  version = "8.0.0";
+
+  src = fetchFromGitHub {
+    owner = "sharkdp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    forceFetchGit = true;
+  };
+}


### PR DESCRIPTION
This also switches owner to lazy matches for consistency.

Fixes: 077f4cfaa48a97d65ab161cc3253218f69f88c29