### PR TITLE
feat(github.py): use all tags for unstable updates

### DIFF
--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -152,7 +152,7 @@ def fetch_github_snapshots(
         else fetch_github_versions_from_feed
     )
     versions = version_fetcher(url, owner, repo)
-    latest_version = versions[0].number if versions else "0"
+    versions = [ version.number for version in versions ] + ["0"]
 
     for entry in commits:
         link = entry.find("{http://www.w3.org/2005/Atom}link")
@@ -167,6 +167,6 @@ def fetch_github_snapshots(
         url = urlparse(link.attrib["href"])
         commit = url.path.rsplit("/", maxsplit=1)[-1]
         date = updated.text.split("T", maxsplit=1)[0]
-        return [Version(f"{latest_version}-unstable-{date}", rev=commit)]
+        return [Version(f"{version}-unstable-{date}", rev=commit) for version in versions]
 
     return []


### PR DESCRIPTION
Closes:
- #322

**Note:** the implementation feels a bit hacky, but it could be very useful in practice so here it is.

This patch hacks around the tag selection issue for unstable updates by simply appending `-unstable-xxxx-xx-xx` to all tags as potential candidates, which can then be filtered by `--version-regex`. Version 0 is included as a final fallback such that:

- To hardcore a 0-unstable-xxxx-xx-xx version one can simply do `--version-regex=(0-unstable-.*)`
- Generic version regex such as `--version-regex=jq-(.*)` also works and would lead to a canonical `x.x.x-unstable-xxxx-xx-xx` version string.