### PR TITLE
Replace savanna test package with one that actually exists

### DIFF
--- a/tests/test_savanna.py
+++ b/tests/test_savanna.py
@@ -12,7 +12,7 @@ from tests import conftest
 def test_update(helpers: conftest.Helpers) -> None:
     try:
         response = urllib.request.urlopen(
-            "https://download.savannah.nongnu.org/releases/fileschanged/?C=M&O=D",
+            "https://download.savannah.nongnu.org/releases/xlog/?C=M&O=D",
             timeout=5,
         )
         response.read()
@@ -38,4 +38,4 @@ def test_update(helpers: conftest.Helpers) -> None:
             stdout=subprocess.PIPE,
             check=False,
         ).stdout.strip()
-        assert tuple(map(int, version.split("."))) >= (0, 6, 8)
+        assert tuple(map(int, version.split("."))) >= (2, 0, 24)

--- a/tests/testpkgs/savanna.nix
+++ b/tests/testpkgs/savanna.nix
@@ -1,19 +1,27 @@
 {
   stdenv,
   fetchurl,
-  gamin,
+  glib,
+  gtk2,
+  pkg-config,
+  hamlib,
 }:
-
 stdenv.mkDerivation rec {
-  pname = "fileschanged";
-  version = "0.6.8";
+  pname = "xlog";
+  version = "2.0.24";
 
   src = fetchurl {
-    url = "mirror://savannah/fileschanged/fileschanged-${version}.tar.gz";
-    sha256 = "0ajc9h023vzpnlqqjli4wbvs0q36nr5p9msc3wzbic8rk687qcxc";
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.gz";
+    hash = "sha256-NYC3LgoLXnJQURcZTc2xHOzOleotrWtOETMBgadf2qU=";
   };
 
-  buildInputs = [ gamin ];
+  # glib-2.62 deprecations
+  env.NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
 
-  doCheck = true;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    glib
+    gtk2
+    hamlib
+  ];
 }


### PR DESCRIPTION
It got removed in https://github.com/NixOS/nixpkgs/pull/305197 with gamin and now eval fails which fails the test.

This is required to create a new release.