### PR TITLE
Match last "got" in stderr to avoid false positives

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -135,7 +135,7 @@ def nix_prefetch(opts: Options, attr: str) -> str:
         # expected 'xxx' but got 'xxx'
         regex = re.compile(r".*got(:|\s)\s*'?([^']*)('|$)")
         got = ""
-        for line in stderr.split("\n"):
+        for line in reversed(stderr.split("\n")):
             if match := regex.fullmatch(line):
                 got = match[2]
                 break


### PR DESCRIPTION
Due to the changes introduced in #349 the hash regex matches the output of pnpm when downloading the https://www.npmjs.com/package/got library. This causes the tool to incorrectly update the hash to the "got" version. To fix this I simply changed the for loop to look for the last regex match in the stderr instead of the first, since the nix hash mismatch message is usually printed last.