### PR TITLE
feat: add support for updating zig dependencies

### DIFF
--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -64,6 +64,7 @@ class Package:
     composer_deps_old: str | None
     maven_deps: str | None
     mix_deps: str | None
+    zig_deps: str | None
     has_nuget_deps: bool
     tests: list[str]
     has_update_script: bool
@@ -203,6 +204,7 @@ in {{
   maven_deps = pkg.fetchedMavenDeps.outputHash or null;
   has_nuget_deps = pkg ? nugetDeps;
   mix_deps = pkg.mixFodDeps.outputHash or null;
+  zig_deps = pkg.zigDeps.outputHash or null;
   tests = builtins.attrNames (pkg.passthru.tests or {{}});
   has_update_script = {has_update_script};
   src_homepage = pkg.src.meta.homepage or null;

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -301,6 +301,11 @@ def update_npm_deps_hash(opts: Options, filename: str, current_hash: str) -> Non
     replace_hash(filename, current_hash, target_hash)
 
 
+def update_zig_deps_hash(opts: Options, filename: str, current_hash: str) -> None:
+    target_hash = nix_prefetch(opts, "zigDeps")
+    replace_hash(filename, current_hash, target_hash)
+
+
 def update_yarn_deps_hash(opts: Options, filename: str, current_hash: str) -> None:
     target_hash = nix_prefetch(opts, "yarnOfflineCache")
     replace_hash(filename, current_hash, target_hash)
@@ -586,6 +591,9 @@ def update(opts: Options) -> Package:
 
         if package.has_nuget_deps:
             update_nuget_deps(opts)
+
+        if package.zig_deps:
+            update_zig_deps_hash(opts, package.filename, package.zig_deps)
 
         if isinstance(package.cargo_lock, CargoLockInSource | CargoLockInStore):
             if opts.generate_lockfile:


### PR DESCRIPTION
This adds support for updating Zig dependencies in `nixpkgs`, and will go hand-in-hand with [this PR](https://github.com/nixos/nixpkgs/pull/438523) that introduces a new fixed-output derivation fetcher for Zig dependencies.

I'm not sure if this is allowed, since no actual code uses this yet, but I thought I'd give it a shot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zig dependencies: packages with Zig deps are now detected during evaluation and their hashes are automatically updated in the standard update flow, alongside other ecosystems.

* **Tests**
  * Updated test expectations for version diff URLs to reflect the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->