### PR TITLE
github releases for onpremise installations

### DIFF
--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -82,8 +82,13 @@ def fetch_github_versions_from_releases(
     owner: str,
     repo: str,
 ) -> list[Version]:
-    # TODO: pagination?
     github_url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100"
+    if url.netloc not in {"github.com", "api.github.com"}:
+        github_url = (
+            f"https://{url.netloc}/api/v3/repos/{owner}/{repo}/releases?per_page=100"
+        )
+
+    # TODO: pagination?
     token = os.environ.get("GITHUB_TOKEN")
     extra_headers = {} if token is None else {"Authorization": f"Bearer {token}"}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub Enterprise and other non-default GitHub hosts when fetching releases. The app now auto-detects the repository host and uses the appropriate API endpoint, preserving existing authentication and parsing behavior. Behavior for github.com remains unchanged. No changes to public interfaces or configuration are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->