### PR TITLE
fix: propogate extra_flags to all nix commands

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -461,8 +461,8 @@ def run_update_script(package: Package, opts: Options) -> None:
     update_script = run(
         [
             "nix",
-            *opts.extra_flags,
             "build",
+            *opts.extra_flags,
             "--print-out-paths",
             "--impure",
             "--expr",


### PR DESCRIPTION
Fixes #442 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - You can now supply additional Nix flags to update commands, giving more control over shell, build, and develop operations.
  - Applies consistently across flake and non-flake paths.
  - If no extra flags are provided, existing behavior remains unchanged.

- Chores
  - Command invocation handling streamlined to uniformly accept optional extra flags without changing public interfaces or defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->