### PR TITLE
add --extra-experimental-features to all nix commands

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -340,7 +340,7 @@ def validate_git_dir(import_path: str) -> str:
 
 
 def nix_run(options: Options) -> None:
-    cmd = ["nix", "shell", "-L", *options.extra_flags]
+    cmd = ["nix", "--extra-experimental-features", "nix-command", "shell", "-L", *options.extra_flags]
 
     if options.flake:
         cmd.append(f"{options.import_path}#{options.attribute}")
@@ -361,7 +361,7 @@ def nix_build_tool() -> str:
 
 
 def nix_build(options: Options) -> None:
-    cmd = [nix_build_tool(), "build", "-L", *options.extra_flags]
+    cmd = [nix_build_tool(), "--extra-experimental-features", "nix-command flakes", "build", "-L", *options.extra_flags]
     if options.flake:
         cmd.append(f"{options.import_path}#{options.attribute}")
     else:
@@ -373,7 +373,7 @@ def nix_test(opts: Options, package: Package) -> None:
     if not package.tests:
         die(f"Package '{package.name}' does not define any tests")
 
-    cmd = [nix_build_tool(), "build", "-L", *opts.extra_flags]
+    cmd = [nix_build_tool(), "--extra-experimental-features", "nix-command flakes", "build", "-L", *opts.extra_flags]
 
     if opts.flake:
         cmd.extend(

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -222,7 +222,7 @@ def eval_attr(opts: Options) -> Package:
         system=opts.system,
         override_filename=opts.override_filename,
     )
-    cmd = ["nix", "eval", "--json", "--impure", "--expr", expr, *opts.extra_flags]
+    cmd = ["nix", "--extra-experimental-features", "nix-command", "eval", "--json", "--impure", "--expr", expr, *opts.extra_flags]
     res = run(cmd)
     out = json.loads(res.stdout)
     if opts.override_filename is not None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All run, build, test, and eval operations now execute with nix-command enabled for improved compatibility with modern Nix.
  * Flakes support is automatically enabled where applicable.
  * No configuration changes required; behavior is transparent to users.
* **Refactor**
  * Updated command invocations to include the necessary experimental feature flags without altering control flow or error handling.
* **Chores**
  * No changes to public interfaces or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->