### PR TITLE
add --extra-experimental-features to all nix commands

### DIFF
--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import ParseResult, urlparse
 
 from .errors import UpdateError
-from .utils import run
+from .utils import nix_command, run
 from .version.version import Version, VersionPreference
 
 if TYPE_CHECKING:
@@ -222,7 +222,7 @@ def eval_attr(opts: Options) -> Package:
         system=opts.system,
         override_filename=opts.override_filename,
     )
-    cmd = ["nix", "--extra-experimental-features", "nix-command", "eval", "--json", "--impure", "--expr", expr, *opts.extra_flags]
+    cmd = nix_command("eval", "--json", "--impure", "--expr", expr, *opts.extra_flags)
     res = run(cmd)
     out = json.loads(res.stdout)
     if opts.override_filename is not None:

--- a/nix_update/utils.py
+++ b/nix_update/utils.py
@@ -60,3 +60,8 @@ def run(  # noqa: PLR0913
         stderr=stderr,
         env=env,
     )
+
+
+def nix_command(*args: str) -> list[str]:
+    """Return nix command with experimental features enabled."""
+    return ["nix", "--extra-experimental-features", "nix-command flakes", *args]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures Nix experimental features are enabled by default, reducing command failures and improving compatibility.

- Refactor
  - Centralized Nix CLI construction through a unified command builder for consistent run, build and eval behavior.
  - Standardized build/test command generation to reduce duplication and improve reliability.

- Chores
  - Exposed the unified command builder in the public API and migrated existing callers to it; removed the legacy build-tool helper.
  - Updated docstrings and public-facing documentation to reflect the new command approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->