### PR TITLE
mark canary releases as unstable

### DIFF
--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -106,7 +106,7 @@ def extract_version(version: Version, version_regex: str) -> Version | None:
 def is_unstable(version: Version, extracted: str) -> bool:
     if version.prerelease is not None:
         return version.prerelease
-    pattern = "rc|alpha|beta|preview|nightly|prerelease|m[0-9]+"
+    pattern = "alpha|beta|canary|m[0-9]+|nightly|prerelease|preview|rc"
     return re.search(pattern, extracted, re.IGNORECASE) is not None
 
 


### PR DESCRIPTION
I ran across this in fermyon-spin when working on 443625.

I also sorted the regex alphabetically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version stability detection now recognizes “canary” as an unstable marker, alongside alpha, beta, nightly, prerelease, preview, rc, and mN patterns. Versions containing these tokens (case-insensitive) are treated as unstable when no prerelease component is present, improving the accuracy of stability checks and any automations or workflows that rely on them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->