### PR TITLE
Pass desired output aarch as eval-system argument to nix

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -167,7 +167,7 @@ def parse_args(args: list[str]) -> Options:
     a = parser.parse_args(args)
     extra_flags = ["--extra-experimental-features", "flakes nix-command"]
     if a.system:
-        extra_flags.extend(["--system", a.system])
+        extra_flags.extend(["--eval-system", a.system])
     for name, value in a.option:
         extra_flags.extend(["--option", name, value])
 


### PR DESCRIPTION
This change activates remote builders to build packages for other platforms instead of forcing the current host to be target platform-compatible (feature introduced in #130).

**It's unclear to me if this is also a solution to the original issue (https://github.com/Mic92/nix-update/issues/129) or a separate parameter on nix-update `eval-system` is required/desired.**

Fixes #479.

This change updates the following pseudo package recipe as intuitively expected;

```nix
{
  lib,
  stdenv,
  fetchurl,
  _experimental-update-script-combinators,
  nix-update-script,
}:
let
  version = "2.0.88";
  sourceMap = {
    aarch64-linux = fetchurl {
      url = "https://github.com/netbootxyz/netboot.xyz/releases/download/${version}/netboot.xyz-arm64.efi";
      hash = "sha256-AeW92FU65XVJKGPi+A/iz7Jvtb7wKIO3xG3Cx7v4kRg=";
    };
    x86_64-linux = fetchurl {
      url = "https://github.com/netbootxyz/netboot.xyz/releases/download/${version}/netboot.xyz.efi";
      hash = "sha256-ipbZJ0mPCuwzb/TDtXXUBTuWOcSsKGAJ1GEGIgB2G7E=";
    };
  };
in
stdenv.mkDerivation (finalAttrs: {
  pname = "netboot.xyz-efi";
  inherit version;

  src =
    sourceMap.${stdenv.hostPlatform.system}
      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");

  passthru.updateScript = _experimental-update-script-combinators.sequence [
    (nix-update-script { extraArgs = ["--system" "x86_64-linux"]})
    (nix-update-script { extraArgs = ["--system" "aarch64-linux" "--version" "skip"]})
  ];
  # ---
})
```

into 

```nix
# ---
 sourceMap = {
    version = "2.0.89";
    aarch64-linux = fetchurl {
      url = "https://github.com/netbootxyz/netboot.xyz/releases/download/${version}/netboot.xyz-arm64.efi";
      hash = "sha256-N1s2l3+8zPX1eBKtKIVaKqr7DDUiUXlu/0lNR1EJmRs=";
    };
    x86_64-linux = fetchurl {
      url = "https://github.com/netbootxyz/netboot.xyz/releases/download/${version}/netboot.xyz.efi";
      hash = "sha256-rmMU/OTOh7zId+zwQCXHt2SJyBAtLNfCOZhDyrkBKjw=";
    };
  };
# ---
```