### PR TITLE
Add support for fixed-output derivation subpackages

### DIFF
--- a/nix_update/dependency_hashes.py
+++ b/nix_update/dependency_hashes.py
@@ -51,8 +51,11 @@ def extract_hash_from_nix_error(stderr: str) -> str | None:
     return None
 
 
-def nix_prefetch(opts: Options, attr: str) -> str:
-    expr = f"{opts.get_package()}.{attr}"
+def nix_prefetch(opts: Options, attr: str | None) -> str:
+    expr = opts.get_package()
+
+    if attr is not None:
+        expr += f".{attr}"
 
     extra_env: dict[str, str] = {}
     tempdir: tempfile.TemporaryDirectory[str] | None = None
@@ -89,7 +92,7 @@ def nix_prefetch(opts: Options, attr: str) -> str:
 
 
 def update_hash_with_prefetch(
-    attr_name: str,
+    attr_name: str | None,
     opts: Options,
     filename: str,
     current_hash: str,
@@ -129,6 +132,7 @@ def update_dependency_hashes(
         return
 
     hash_updaters: dict[str, Callable[[Options, str, Any], None]] = {
+        "fod_subpackage": partial(update_hash_with_prefetch, None),
         "go_modules": partial(update_hash_with_prefetch, "goModules"),
         "go_modules_old": partial(update_hash_with_prefetch, "go-modules"),
         "cargo_deps": partial(update_hash_with_prefetch, "cargoDeps"),

--- a/nix_update/eval.nix
+++ b/nix_update/eval.nix
@@ -112,6 +112,7 @@ in
   rev = pkg.src.rev or null;
   tag = pkg.src.tag or null;
   hash = pkg.src.outputHash or null;
+  fod_subpackage = pkg.outputHash or null;
   go_modules = pkg.goModules.outputHash or null;
   go_modules_old = pkg.go-modules.outputHash or null;
   cargo_deps = pkg.cargoDeps.outputHash or null;

--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -52,6 +52,7 @@ class Package:
     rev: str | None
     tag: str | None
     hash: str | None
+    fod_subpackage: str | None
     go_modules: str | None
     go_modules_old: str | None
     cargo_deps: str | None

--- a/tests/test_fod_subpackage.py
+++ b/tests/test_fod_subpackage.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+from nix_update.options import Options
+from nix_update.update import update
+from nix_update.version.version import VersionPreference
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_update(testpkgs: Path) -> None:
+    opts = Options(
+        attribute="fod-subpackage",
+        subpackages=["node_modules"],
+        import_path=str(testpkgs),
+        version_preference=VersionPreference.SKIP,
+    )
+    update(opts)
+
+    def get_attr(attr: str) -> str:
+        return subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--raw",
+                "--extra-experimental-features",
+                "nix-command",
+                "-f",
+                testpkgs,
+                attr,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+
+    subpackage_hash = get_attr("fod-subpackage.node_modules.outputHash")
+    assert subpackage_hash != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+    src_hash = get_attr("fod-subpackage.src.outputHash")
+    assert src_hash != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -17,6 +17,7 @@
   cargoVendorDeps.nonRustPackage = pkgs.callPackage ./cargo-vendor-deps/non-rust-package.nix { };
   cargoVendorDeps.rustPackage = pkgs.callPackage ./cargo-vendor-deps/rust-package.nix { };
   composer-old = pkgs.callPackage ./composer-old.nix { };
+  fod-subpackage = pkgs.callPackage ./fod-subpackage.nix { };
   crate = pkgs.callPackage ./crate.nix { };
   fetchurl-github-release = pkgs.callPackage ./fetchurl-github-release.nix { };
   flake-use-update-script = pkgs.callPackage ./flake-use-update-script.nix { };

--- a/tests/testpkgs/fod-subpackage.nix
+++ b/tests/testpkgs/fod-subpackage.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenvNoCC,
+  bun,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}:
+let
+  pname = "models-dev";
+  version = "0-unstable-2025-11-28";
+  src = fetchFromGitHub {
+    owner = "sst";
+    repo = "models.dev";
+    rev = "48358b91b776d0bd34cbbc4c70e7ac5ce827b916";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    postFetch = lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+      # NOTE: Normalize case-sensitive directory names that cause issues on case-insensitive filesystems
+      cp -r "$out/providers/poe/models/openai"/* "$out/providers/poe/models/openAi/"
+      rm -rf "$out/providers/poe/models/openai"
+    '';
+  };
+
+  node_modules = stdenvNoCC.mkDerivation {
+    pname = "${pname}-node_modules";
+    inherit version src;
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+       export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+
+       bun install \
+         --filter=./packages/web \
+         --force \
+         --frozen-lockfile \
+         --ignore-scripts \
+         --no-progress \
+         --production
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      find . -type d -name node_modules -exec cp -R --parents {} $out \;
+
+      runHook postInstall
+    '';
+
+    # NOTE: Required else we get errors that our fixed-output derivation references store paths
+    dontFixup = true;
+
+    outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+stdenvNoCC.mkDerivation (_finalAttrs: {
+  inherit
+    pname
+    version
+    src
+    node_modules
+    ;
+
+  nativeBuildInputs = [ bun ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${node_modules}/. .
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd packages/web
+    bun run ./script/build.ts
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/dist
+    cp -R ./dist $out
+
+    runHook postInstall
+  '';
+})


### PR DESCRIPTION
Adds support for updating fixed-output derivation subpackages. For example a package with a fixed-output derivation 'subpackage':

```nix
let
  pname = "some-package";
  version = "1.0.0";
  src = fetchFromGitHub {
    owner = "owner";
    repo = "repo";
    rev = "v${version}";
    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
  };

  subpackage = mkDerivation (finalAttrs: {
    ...
    outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
  });
in
mkDerivation (finalAttrs: {
  inherit node_modules pname version src;
  ...
})
```