### PR TITLE
nix hashing format fix

### DIFF
--- a/nix_update/hashes.py
+++ b/nix_update/hashes.py
@@ -11,7 +11,7 @@ SHA1_HASH_LENGTH = 40
 
 def to_sri(hashstr: str) -> str:
     """Convert a hash string to SRI format if needed."""
-    if "-" in hashstr:
+    if "-" in hashstr or ":" in hashstr:
         return hashstr
     length = len(hashstr)
     if length == MD5_HASH_LENGTH:


### PR DESCRIPTION
hashing format `sha256:sha256:0ysps2384nzrjrbl9f6gcwmq1fmcb2jp3vcxkvmv9wiasvmy893z` causes errors

```
  File "/nix/store/cdaifv92znxy5ai4sawricjl0p5b9sgf-python3-3.13.11/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['nix', '--extra-experimental-features', 'nix-command', 'hash', 'to-sri', 'sha256:sha256:0ysps2384nzrjrbl9f6gcwmq1fmcb2jp3vcxkvmv9wiasvmy893z']' returned non-zero exit status 1.
```