### PR TITLE
test_version_regex_no_rev: relax regex constraint

### DIFF
--- a/tests/test_version_regex_no_rev.py
+++ b/tests/test_version_regex_no_rev.py
@@ -17,7 +17,7 @@ def test_main(testpkgs_git: Path) -> None:
             "--commit",
             "net-news-wire",
             "--version-regex",
-            "^mac-(\\d+\\.\\d+\\.\\d+(?:b\\d+)?)$",
+            r"^mac-(\d+\.\d+(\.\d+)?(?:b\d+)?)$",
         ],
     )
     version = get_nix_value(testpkgs_git, "net-news-wire.version")


### PR DESCRIPTION
Looks like upstream started doing versions like `mac-7.0b5` which the previous regex wasn't able to cover