### PR TITLE
tests: use invent.kde.org for gitlab test

### DIFF
--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -26,7 +26,7 @@ def test_main(testpkgs_git: Path) -> None:
         text=True,
         stdout=subprocess.PIPE,
     ).stdout.strip()
-    assert tuple(map(int, version.split("."))) >= (0, 3, 0)
+    assert tuple(map(int, version.split("."))) >= (1, 1, 0)
     commit = subprocess.run(
         ["git", "-C", str(testpkgs_git), "log", "-1"],
         text=True,
@@ -37,6 +37,6 @@ def test_main(testpkgs_git: Path) -> None:
     assert version in commit
     assert "gitlab" in commit
     assert (
-        "https://gitlab.com/interception/linux/plugins/caps2esc/-/compare/v0.1.3...v"
+        "https://invent.kde.org/libraries/kirigami-addons/-/compare/v1.0.0...v"
         in commit
     )

--- a/tests/testpkgs/gitlab.nix
+++ b/tests/testpkgs/gitlab.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitLab }:
 
 stdenv.mkDerivation rec {
-  pname = "caps2esc";
-  version = "0.1.3";
+  pname = "kirigami-addons";
+  version = "1.0.0";
 
   src = fetchFromGitLab {
-    group = "interception";
-    owner = "linux/plugins";
+    domain = "invent.kde.org";
+    owner = "libraries";
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";


### PR DESCRIPTION
The caps2esc test on gitlab.com doesn't exercise the custom `domain` code path in version fetching and diff URL generation. Switch to kirigami-addons on invent.kde.org to cover self-hosted GitLab instances.

Tested locally - passes.