### PR TITLE
chore: Add Python with mypy, pytest, and ruff to devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,11 +40,11 @@
               packages = [
                 (pkgs.python3.withPackages (
                   ps: with ps; [
-                    mypy
                     pytest
-                    ruff
                   ]
                 ))
+                pkgs.mypy
+                pkgs.ruff
               ];
               # Make tests use our pinned Nixpkgs
               env.NIX_PATH = "nixpkgs=${pkgs.path}";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ warn_redundant_casts = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 no_implicit_optional = true
+packages = ["nix_update"]
 
 [[tool.mypy.overrides]]
 module = "setuptools.*"


### PR DESCRIPTION
This adds the tools directly to `PATH`, allowing developers to invoke them directly without `nix develop -c`.