### PR TITLE
fix: don't cache flake store path across file modifications

### DIFF
--- a/nix_update/eval.py
+++ b/nix_update/eval.py
@@ -138,8 +138,9 @@ def eval_attr(opts: Options) -> Package:
         "false" if opts.override_filename else "true",
     ]
 
-    if opts.flake_import_path is not None:
-        cmd.extend(["--argstr", "flakeImportPath", opts.flake_import_path])
+    flake_store_path = opts.get_flake_import_path()
+    if flake_store_path is not None:
+        cmd.extend(["--argstr", "flakeImportPath", flake_store_path])
 
     if opts.system:
         cmd.extend(["--argstr", "system", opts.system])

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -187,8 +187,6 @@ def run_update_script(package: Package, opts: Options) -> None:
         ],
         cwd=opts.import_path,
     )
-    # Reset flake_import_path so subsequent evals pick up changes from local directory
-    opts.flake_import_path = None
 
 
 def update(opts: Options) -> Package:

--- a/tests/test_flake_import_path_reset.py
+++ b/tests/test_flake_import_path_reset.py
@@ -1,0 +1,55 @@
+"""Test that flake store path reflects current on-disk content.
+
+Regression test for https://github.com/Mic92/nix-update/issues/537
+After the version is updated in local files, evaluations (e.g. hash
+prefetching) must see the new version — not a stale store copy from
+before the update.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nix_update.eval import eval_attr
+from nix_update.options import Options
+from nix_update.update import update_version
+from nix_update.version.version import VersionPreference
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_flake_store_path_reflects_version_update(testpkgs_git: Path) -> None:
+    """get_flake_import_path() must return a different store path after a version change."""
+    opts = Options(
+        attribute="crate",
+        flake=True,
+        import_path=str(testpkgs_git),
+        version="10.2.0",
+        version_preference=VersionPreference.FIXED,
+    )
+
+    # Snapshot the store path before the update
+    path_before = opts.get_flake_import_path()
+    assert path_before is not None
+
+    package = eval_attr(opts)
+
+    # Update the version — modifies local files
+    changed = update_version(
+        opts,
+        package,
+        "10.2.0",
+        VersionPreference.FIXED,
+        "(.*)",
+    )
+    assert changed, "Version should have changed from 8.0.0 to 10.2.0"
+
+    # The store path must now differ because the on-disk content changed
+    path_after = opts.get_flake_import_path()
+    assert path_after is not None
+    assert path_after != path_before, (
+        f"get_flake_import_path() returned the same store path before and after "
+        f"the version update ({path_before}), so subsequent evaluations would "
+        f"use stale content"
+    )


### PR DESCRIPTION
The flake store path (from `nix flake metadata`) was cached in opts.flake_import_path after the first call.  When local files were subsequently modified (version bump, hash update, lockfile generation), the cached path still pointed at the old store copy.  This caused builtins.getFlake to evaluate stale content — most visibly producing the wrong source hash (the old version's hash instead of the new one).

Instead of trying to invalidate the cache at every mutation site (which is error-prone and was already missed once), remove the cache entirely. get_flake_import_path() now always calls `nix flake metadata` to get a store path that reflects the current on-disk content.

Fixes: https://github.com/Mic92/nix-update/issues/537