### PR TITLE
Document the need to put subpackages in passthru 

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ buildGoModule rec {
 ```
 
 Note that you must add the subpackage to passthrough in order for `nix-update`
-to be able to discover it.
+to be able to access it.
 
 You can update the package and its subpackage using `nix-update` as follows:
 


### PR DESCRIPTION
Just spent a few hours trying to figure out why I couldn't update a package with subpackages. Kept running into this error: 

```
error:
       … while evaluating attribute 'filename'
         at /nix/store/nkbrgiymqjsvczd66pa0agbwgqi262h6-nix-update-v1.14.0/lib/python3.13/site-packages/nix_update/eval.nix:112:3:
          111|   inherit raw_version_position;
          112|   filename = position.file;
             |   ^
          113|   line = position.line;

       … while evaluating a branch condition
         at /nix/store/nkbrgiymqjsvczd66pa0agbwgqi262h6-nix-update-v1.14.0/lib/python3.13/site-packages/nix_update/eval.nix:99:10:
           98|       raw_version_position
           99|     else if (builtins.unsafeGetAttrPos "src" pkg) != null then
             |          ^
          100|       sanitizePosition (builtins.unsafeGetAttrPos "src" pkg)

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: expected a set but found null: null
```

Turns out that when using `--subpackage` you must set the subpackage in `passthru`. However this was not in the example. I only figured this out because of https://github.com/Mic92/nix-update/issues/512#issuecomment-3621915401

I feel like this should be documented :) 