### PR TITLE
Sort fetched versions by semver instead of feed order

### DIFF
--- a/nix_update/version_compare.py
+++ b/nix_update/version_compare.py
@@ -1,0 +1,272 @@
+"""
+Version comparison for package version strings.
+
+This module implements a sophisticated version comparison algorithm that handles
+complex version strings commonly found in package managers. It supports:
+- Epoch prefixes (e.g., "1:2.0.0")
+- Release suffixes (e.g., "1.0.0-1")
+- Mixed alphanumeric segments
+- Special separator handling
+
+The implementation is inspired by RPM-style version comparison but is an
+independent implementation written specifically for nix-update.
+"""
+
+
+
+class VersionSegment:
+    """Represents a parsed segment of a version string."""
+
+    def __init__(self, value: str, *, is_numeric: bool) -> None:
+        self.value = value
+        self.is_numeric = is_numeric
+
+    def compare_to(self, other: "VersionSegment") -> int:
+        """
+        Compare this segment to another.
+
+        Returns:
+            1 if self > other, -1 if self < other, 0 if equal
+        """
+        # Numeric segments are always considered newer than alpha segments
+        if self.is_numeric and not other.is_numeric:
+            return 1
+        if not self.is_numeric and other.is_numeric:
+            return -1
+
+        if self.is_numeric:
+            # For numeric comparison, strip leading zeros and compare by length first
+            val1 = self.value.lstrip("0") or "0"
+            val2 = other.value.lstrip("0") or "0"
+
+            # Longer number means larger value
+            if len(val1) != len(val2):
+                return 1 if len(val1) > len(val2) else -1
+
+            # Same length, compare lexicographically
+            if val1 < val2:
+                return -1
+            if val1 > val2:
+                return 1
+            return 0
+        # Alphabetic comparison
+        if self.value < other.value:
+            return -1
+        if self.value > other.value:
+            return 1
+        return 0
+
+
+class VersionString:
+    """Represents a complete version string with epoch, version, and release."""
+
+    def __init__(self, version_str: str) -> None:
+        self.epoch, self.version, self.release = self._parse_version(version_str)
+
+    def _parse_version(self, ver: str) -> tuple[str, str, str | None]:
+        """
+        Parse a version string into epoch, version, and release components.
+
+        Format: [epoch:]version[-release]
+        """
+        epoch = "0"
+        version = ver
+        release = None
+
+        # Extract epoch if present (numeric prefix before colon)
+        colon_pos = ver.find(":")
+        if colon_pos > 0 and ver[:colon_pos].isdigit():
+            epoch = ver[:colon_pos]
+            version = ver[colon_pos + 1 :]
+        elif colon_pos == 0:
+            # Empty epoch defaults to 0
+            epoch = "0"
+            version = ver[1:]
+
+        # Extract release if present (suffix after last dash)
+        dash_pos = version.rfind("-")
+        if dash_pos >= 0:
+            release = version[dash_pos + 1 :]
+            version = version[:dash_pos]
+
+        return epoch, version, release
+
+    def _extract_segments(self, s: str) -> list[tuple[VersionSegment, int]]:
+        """
+        Extract alternating alpha/numeric segments with separator lengths.
+
+        Returns list of (segment, separator_length_before) tuples.
+        """
+        segments: list[tuple[VersionSegment, int]] = []
+        pos = 0
+
+        while pos < len(s):
+            # Skip non-alphanumeric characters
+            sep_start = pos
+            while pos < len(s) and not s[pos].isalnum():
+                pos += 1
+
+            if pos >= len(s):
+                break
+
+            sep_len = pos - sep_start
+
+            # Extract segment (all digits or all letters)
+            seg_start = pos
+            if s[pos].isdigit():
+                while pos < len(s) and s[pos].isdigit():
+                    pos += 1
+                segment = VersionSegment(s[seg_start:pos], is_numeric=True)
+            else:
+                while pos < len(s) and s[pos].isalpha():
+                    pos += 1
+                segment = VersionSegment(s[seg_start:pos], is_numeric=False)
+
+            segments.append((segment, sep_len))
+
+        return segments
+
+    def _compare_segment_lists(
+        self,
+        segs1: list[tuple[VersionSegment, int]],
+        segs2: list[tuple[VersionSegment, int]],
+    ) -> int:
+        """Compare two lists of version segments."""
+        for i in range(min(len(segs1), len(segs2))):
+            seg1, sep_len1 = segs1[i]
+            seg2, sep_len2 = segs2[i]
+
+            # Different separator lengths means different versions
+            if i > 0 and sep_len1 != sep_len2:
+                return -1 if sep_len1 < sep_len2 else 1
+
+            # Compare the actual segments
+            result = seg1.compare_to(seg2)
+            if result != 0:
+                return result
+
+        # All compared segments are equal, check if one has more segments
+        if len(segs1) == len(segs2):
+            return 0
+        if len(segs1) < len(segs2):
+            # Second version has more segments
+            next_seg, sep_len = segs2[len(segs1)]
+
+            if next_seg.is_numeric:
+                # Numeric segment always makes version newer
+                return -1
+            # Alpha segment behavior depends on separator:
+            # - With separator (sep_len > 0): treated as new segment, makes version newer
+            # - Without separator (sep_len == 0): treated as pre-release suffix, makes version older
+            if sep_len > 0:
+                return -1  # Has separator, newer version
+            return 1  # No separator, pre-release marker
+        # First version has more segments
+        next_seg, sep_len = segs1[len(segs2)]
+
+        if next_seg.is_numeric:
+            # Numeric segment always makes version newer
+            return 1
+        # Alpha segment behavior depends on separator:
+        # - With separator (sep_len > 0): treated as new segment, makes version newer
+        # - Without separator (sep_len == 0): treated as pre-release suffix, makes version older
+        if sep_len > 0:
+            return 1  # Has separator, newer version
+        return -1  # No separator, pre-release marker
+
+    def _compare_component(self, comp1: str, comp2: str) -> int:
+        """Compare two version components (epoch, version, or release)."""
+        if comp1 == comp2:
+            return 0
+
+        segs1 = self._extract_segments(comp1)
+        segs2 = self._extract_segments(comp2)
+
+        return self._compare_segment_lists(segs1, segs2)
+
+    def compare_to(self, other: "VersionString") -> int:
+        """
+        Compare this version to another.
+
+        Returns:
+            1 if self > other, -1 if self < other, 0 if equal
+        """
+        # Compare epochs first
+        result = self._compare_component(self.epoch, other.epoch)
+        if result != 0:
+            return result
+
+        # Compare versions
+        result = self._compare_component(self.version, other.version)
+        if result != 0:
+            return result
+
+        # Compare releases if both exist
+        if self.release is not None and other.release is not None:
+            return self._compare_component(self.release, other.release)
+
+        # Version with release is considered newer than without
+        if self.release is not None:
+            return 1
+        if other.release is not None:
+            return -1
+
+        return 0
+
+
+def version_compare(a: str | None, b: str | None) -> int:
+    """
+    Compare two package version strings.
+
+    This function handles version strings in the format:
+        [epoch:]version[-release]
+
+    Where:
+        - epoch: Optional numeric prefix followed by colon (e.g., "1:")
+        - version: The main version string
+        - release: Optional release number after a dash (e.g., "-1")
+
+    The comparison algorithm:
+    1. Compares epochs numerically (if present)
+    2. Compares version segments (numeric > alpha, longer numeric > shorter)
+    3. Compares release segments (if present)
+    4. Considers separator lengths when comparing
+
+    Examples:
+        >>> version_compare("1.0.0", "2.0.0")
+        -1
+        >>> version_compare("2.0.0", "1.0.0")
+        1
+        >>> version_compare("1.0.0", "1.0.0")
+        0
+        >>> version_compare("1:1.0.0", "2.0.0")
+        1
+        >>> version_compare("1.0.0-1", "1.0.0-2")
+        -1
+
+    Args:
+        a: First version string (can be None)
+        b: Second version string (can be None)
+
+    Returns:
+        1 if a is newer than b
+        0 if a and b are the same version
+        -1 if b is newer than a
+    """
+    # Handle None values
+    if a is None and b is None:
+        return 0
+    if a is None:
+        return -1
+    if b is None:
+        return 1
+
+    # Quick shortcut for identical strings
+    if a == b:
+        return 0
+
+    # Parse and compare version strings
+    ver_a = VersionString(a)
+    ver_b = VersionString(b)
+
+    return ver_a.compare_to(ver_b)

--- a/tests/test_version_compare.py
+++ b/tests/test_version_compare.py
@@ -1,0 +1,100 @@
+"""
+Test suite for version_compare module.
+
+These tests verify the version comparison algorithm handles various
+version string formats correctly, including epochs, releases, and
+mixed alphanumeric segments.
+"""
+
+import pytest
+
+from nix_update.version_compare import version_compare
+
+
+@pytest.mark.parametrize(
+    ("ver1", "ver2", "expected"),
+    [
+        # Basic comparisons
+        ("1.5.0", "1.5.0", 0),
+        ("1.5.1", "1.5.0", 1),
+        ("1.5.1", "1.5", 1),
+        # With package release
+        ("1.5.0-1", "1.5.0-1", 0),
+        ("1.5.0-1", "1.5.0-2", -1),
+        ("1.5.0-1", "1.5.1-1", -1),
+        ("1.5.0-2", "1.5.1-1", -1),
+        ("1.5-1", "1.5.1-1", -1),
+        ("1.5-2", "1.5.1-1", -1),
+        ("1.5-2", "1.5.1-2", -1),
+        # Mixed package release inclusion
+        ("1.5", "1.5-1", -1),
+        ("1.1-1", "1.1", 1),
+        ("1.0-1", "1.1", -1),
+        ("1.1-1", "1.0", 1),
+        # Alphanumeric versions
+        ("1.5b-1", "1.5-1", -1),
+        ("1.5b", "1.5", -1),
+        ("1.5b-1", "1.5", -1),
+        ("1.5b", "1.5.1", -1),
+        # From the manpage
+        ("1.0a", "1.0alpha", -1),
+        ("1.0alpha", "1.0b", -1),
+        ("1.0b", "1.0beta", -1),
+        ("1.0beta", "1.0rc", -1),
+        ("1.0rc", "1.0", -1),
+        # Alpha-dotted versions
+        ("1.5.a", "1.5", 1),
+        ("1.5.b", "1.5.a", 1),
+        ("1.5.1", "1.5.b", 1),
+        # Alpha dots and dashes
+        ("1.5.b-1", "1.5.b", 1),
+        ("1.5-1", "1.5.b", -1),
+        # Same/similar content, differing separators
+        ("2.0", "2_0", 0),
+        ("2.0_a", "2_0.a", 0),
+        ("2.0a", "2.0.a", -1),
+        ("2___a", "2_a", 1),
+        # Epoch included version comparisons
+        ("0:1.0", "0:1.0", 0),
+        ("0:1.0", "0:1.1", -1),
+        ("1:1.0", "0:1.0", 1),
+        ("1:1.0", "0:1.1", 1),
+        ("1:1.0", "2:1.1", -1),
+        # Epoch + sometimes present pkgrel
+        ("1:1.0", "0:1.0-1", 1),
+        ("1:1.0-1", "0:1.1-1", 1),
+        # Epoch included on one version
+        ("0:1.0", "1.0", 0),
+        ("0:1.0", "1.1", -1),
+        ("0:1.1", "1.0", 1),
+        ("1:1.0", "1.0", 1),
+        ("1:1.0", "1.1", 1),
+        ("1:1.1", "1.1", 1),
+        # None handling
+        (None, None, 0),
+        (None, "1.0", -1),
+        ("1.0", None, 1),
+        # Real-world examples
+        ("3.9.0", "3.10.0", -1),
+        ("3.10.0", "3.9.0", 1),
+        ("3.9.17", "3.9.18", -1),
+        ("1.2.3", "1.2.4", -1),
+        ("1.3.0", "1.2.9", 1),
+        ("2.0.0", "1.99.99", 1),
+        ("1.0.0rc1", "1.0.0rc2", -1),
+        ("1.0.0rc2", "1.0.0", -1),
+        ("1.0.0beta", "1.0.0rc", -1),
+        ("1.0.0alpha", "1.0.0beta", -1),
+        ("5.15.0", "5.16.0", -1),
+        ("5.15.10", "5.15.9", 1),
+        ("6.0.0", "5.19.0", 1),
+        ("1.0.0.r5.gabcdef", "1.0.0.r6.gabcdef", -1),
+        ("1.0.0.r10.gabcdef", "1.0.0.r9.gabcdef", 1),
+    ],
+)
+def test_version_compare(ver1: str | None, ver2: str | None, expected: int) -> None:
+    """Test version comparison returns expected result."""
+    assert version_compare(ver1, ver2) == expected
+    # Also test symmetry: version_compare(a, b) == -version_compare(b, a)
+    if ver1 is not None and ver2 is not None:
+        assert version_compare(ver2, ver1) == -expected

--- a/tests/test_version_sorting.py
+++ b/tests/test_version_sorting.py
@@ -1,0 +1,129 @@
+"""
+Test that fetch_latest_version picks the highest semver version,
+not the most recently published one.
+
+This covers the scenario where upstream maintains multiple release
+branches and publishes patch releases for older branches after newer
+minor/major versions exist (e.g. openshift-pipelines/pipelines-as-code
+publishes v0.39.5 after v0.41.1).
+"""
+
+from __future__ import annotations
+
+import io
+import unittest.mock
+import xml.etree.ElementTree as ET
+from urllib.parse import urlparse
+
+from nix_update.version import VersionFetchConfig, fetch_latest_version
+from nix_update.version.version import VersionPreference
+
+
+def _build_github_atom_feed(releases: list[str]) -> bytes:
+    """Build a minimal GitHub-style Atom feed with entries in the given order."""
+    ns = "http://www.w3.org/2005/Atom"
+    feed = ET.Element(f"{{{ns}}}feed")
+    ET.SubElement(feed, f"{{{ns}}}title").text = "Release feed"
+    for tag in releases:
+        entry = ET.SubElement(feed, f"{{{ns}}}entry")
+        link = ET.SubElement(entry, f"{{{ns}}}link")
+        link.set("href", f"https://github.com/owner/repo/releases/tag/{tag}")
+        ET.SubElement(entry, f"{{{ns}}}updated").text = "2026-01-01T00:00:00Z"
+    return ET.tostring(feed, encoding="unicode").encode()
+
+
+def _make_urlopen(feed_bytes: bytes):
+    """Create a fake urlopen that returns the given feed for any URL."""
+
+    def fake_urlopen(request, timeout=None):
+        del timeout
+        resp = io.BytesIO(feed_bytes)
+        resp.status = 200
+        return resp
+
+    return fake_urlopen
+
+
+def test_highest_semver_wins_over_recent_release() -> None:
+    """Simulate the tektoncd-cli-pac scenario: v0.39.5 released after v0.41.1."""
+    # Feed ordered by release date (most recent first) — v0.39.5 is newest
+    feed = _build_github_atom_feed(
+        ["v0.39.5", "v0.37.6", "v0.41.1", "v0.39.4", "v0.37.5", "v0.41.0"],
+    )
+    with unittest.mock.patch(
+        "nix_update.version.github.urllib.request.urlopen",
+        _make_urlopen(feed),
+    ):
+        version = fetch_latest_version(
+            urlparse(
+                "https://github.com/openshift-pipelines/pipelines-as-code/archive/v0.41.1.tar.gz",
+            ),
+            VersionFetchConfig(
+                preference=VersionPreference.STABLE,
+                version_regex=r"v([0-9.]+)",
+            ),
+        )
+        assert version.number == "0.41.1"
+
+
+def test_highest_semver_without_version_regex() -> None:
+    """Even without --version-regex, the highest version should be selected."""
+    feed = _build_github_atom_feed(
+        ["v0.39.5", "v0.41.1", "v0.37.6"],
+    )
+    with unittest.mock.patch(
+        "nix_update.version.github.urllib.request.urlopen",
+        _make_urlopen(feed),
+    ):
+        version = fetch_latest_version(
+            urlparse(
+                "https://github.com/owner/repo/archive/v0.41.1.tar.gz",
+            ),
+            VersionFetchConfig(
+                preference=VersionPreference.STABLE,
+                version_regex=r"(.*)",
+            ),
+        )
+        assert version.number == "v0.41.1"
+
+
+def test_sorting_with_major_version_differences() -> None:
+    """Ensure major version bumps are preferred over older branch patches."""
+    feed = _build_github_atom_feed(
+        ["v1.2.10", "v2.0.0", "v1.3.0", "v1.2.9"],
+    )
+    with unittest.mock.patch(
+        "nix_update.version.github.urllib.request.urlopen",
+        _make_urlopen(feed),
+    ):
+        version = fetch_latest_version(
+            urlparse(
+                "https://github.com/owner/repo/archive/v2.0.0.tar.gz",
+            ),
+            VersionFetchConfig(
+                preference=VersionPreference.STABLE,
+                version_regex=r"v([0-9.]+)",
+            ),
+        )
+        assert version.number == "2.0.0"
+
+
+def test_postgis_scenario() -> None:
+    """PostGIS: 3.5.4 published after 3.6.0 — should pick 3.6.0."""
+    feed = _build_github_atom_feed(
+        ["3.5.4", "3.6.0", "3.5.3", "3.4.5"],
+    )
+    with unittest.mock.patch(
+        "nix_update.version.github.urllib.request.urlopen",
+        _make_urlopen(feed),
+    ):
+        version = fetch_latest_version(
+            urlparse(
+                "https://github.com/postgis/postgis/archive/3.6.0.tar.gz",
+            ),
+            VersionFetchConfig(
+                preference=VersionPreference.STABLE,
+                version_regex=r"([0-9.]+)",
+            ),
+        )
+        assert version.number == "3.6.0"


### PR DESCRIPTION
## Problem

`fetch_latest_version` returns the first version from the upstream feed that passes the regex filter. Since GitHub/GitLab feeds are ordered by **release date**, this causes downgrades when upstream publishes patch releases on older branches after newer versions exist (e.g. `v0.39.5` released after `v0.41.1`).

The `--version-regex` workaround only filters versions — it doesn't change the sort order.

Examples: NixOS/nixpkgs#492517, NixOS/nixpkgs#461118, NixOS/nixpkgs#453826

## Solution

Wires in the `version_compare` module from @Mic92's `version-compare` branch to sort candidate versions by semver (highest first) before selecting.

Fixes #492