### PR TITLE
http.fetch_json: support headers, gitlab: use GITLAB_TOKEN

### DIFF
--- a/nix_update/version/gitlab.py
+++ b/nix_update/version/gitlab.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from datetime import datetime
 from urllib.parse import ParseResult, quote_plus
@@ -22,8 +23,10 @@ def fetch_gitlab_versions(url: ParseResult) -> list[Version]:
     domain = match.group("domain")
     project_id = match.group("project_id")
     gitlab_url = f"https://{domain}/api/v4/projects/{project_id}/repository/tags"
+    token = os.environ.get("GITLAB_TOKEN")
+    headers = {} if token is None else {"Authorization": f"Bearer {token}"}
     info(f"fetch {gitlab_url}")
-    json_tags = fetch_json(gitlab_url)
+    json_tags = fetch_json(gitlab_url, headers=headers)
     if len(json_tags) == 0:
         msg = "No git tags found"
         raise VersionError(msg)
@@ -52,8 +55,10 @@ def fetch_gitlab_snapshots(url: ParseResult, branch: str) -> list[Version]:
     domain = match.group("domain")
     project_id = match.group("project_id")
     gitlab_url = f"https://{domain}/api/v4/projects/{project_id}/repository/commits?ref_name={quote_plus(branch)}"
+    token = os.environ.get("GITLAB_TOKEN")
+    headers = {} if token is None else {"Authorization": f"Bearer {token}"}
     info(f"fetch {gitlab_url}")
-    commits = fetch_json(gitlab_url)
+    commits = fetch_json(gitlab_url, headers=headers)
 
     try:
         versions = fetch_gitlab_versions(url)

--- a/nix_update/version/http.py
+++ b/nix_update/version/http.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 if TYPE_CHECKING:
     from typing import Any
@@ -16,7 +16,9 @@ DEFAULT_TIMEOUT = 60
 def fetch_json(
     url: str,
     timeout: int = DEFAULT_TIMEOUT,
+    headers: dict[str, str] = {},
 ) -> Any:  # noqa: ANN401
     """Fetch JSON data from a URL with proper timeout and error handling."""
-    with urlopen(url, timeout=timeout) as resp:
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=timeout) as resp:
         return json.load(resp)


### PR DESCRIPTION
This will allow updating private GitLab repositories.

We might further want a generic version of in `.version.github._dorequest` in `.version.http`.
