### PR TITLE
Preserve subdirectory flake paths

### DIFF
--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -5,6 +5,7 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
+from typing import Any
 
 from .errors import AttributePathError
 from .version.version import VersionPreference
@@ -88,12 +89,23 @@ def parse_attribute_path(attribute: str) -> list[str]:
     return parts
 
 
+def _metadata_flake_dir(metadata: dict[str, Any]) -> str | None:
+    """Extract the flake subdirectory (``?dir=``) from flake metadata."""
+    for key in ("locked", "resolved", "original"):
+        value = metadata.get(key)
+        if isinstance(value, dict) and isinstance(value.get("dir"), str):
+            return value["dir"]
+    return None
+
+
 def get_flake_store_path(import_path: str) -> str | None:
     """Copy a local flake into the Nix store and return its store path.
 
     Uses ``nix flake metadata`` so that git-ignored files are excluded and
-    only tracked content is copied.  Returns *None* when the command fails
-    (e.g. the directory is not a flake).
+    only tracked content is copied.  For flakes in a subdirectory of a git
+    repository the reported store path is the repository root, so the
+    flake's subdirectory is appended.  Returns *None* when the command
+    fails (e.g. the directory is not a flake).
     """
     try:
         result = subprocess.run(
@@ -104,9 +116,16 @@ def get_flake_store_path(import_path: str) -> str | None:
             check=True,
         )
         metadata = json.loads(result.stdout)
-        return metadata.get("path")
-    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError):
+        path = metadata.get("path")
+        if not isinstance(path, str):
+            return None
+
+        flake_dir = _metadata_flake_dir(metadata)
+        if flake_dir:
+            return str(Path(path) / flake_dir)
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
         return None
+    return path
 
 
 @dataclass

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from nix_update.errors import AttributePathError
-from nix_update.options import parse_attribute_path
+from nix_update.options import get_flake_store_path, parse_attribute_path
 
 
 @pytest.mark.parametrize(
@@ -57,3 +60,18 @@ def test_parse_attribute_path_errors(input_attr: str, error_match: str) -> None:
     """Test that invalid attribute paths raise AttributePathError."""
     with pytest.raises(AttributePathError, match=error_match):
         parse_attribute_path(input_attr)
+
+
+def test_get_flake_store_path_subdir(tmp_path: Path) -> None:
+    """Flakes in a git subdirectory resolve to the subdirectory store path."""
+    subdir = tmp_path / "systems" / "nixos"
+    subdir.mkdir(parents=True)
+    (subdir / "flake.nix").write_text("{ outputs = _: { }; }")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+
+    store_path = get_flake_store_path(str(subdir))
+
+    assert store_path is not None
+    assert store_path.endswith("/systems/nixos")
+    assert (Path(store_path) / "flake.nix").exists()


### PR DESCRIPTION
## Summary
- preserve the `dir` component returned by `nix flake metadata --json` when building the local flake store path
- keep existing behavior for flakes without a subdirectory

## Why
For local flakes addressed with URLs like `git+file:///repo?dir=systems/nixos`, metadata returns the repository store path separately from the flake subdirectory. Using only `metadata["path"]` makes `builtins.getFlake` look for `flake.nix` at the repository root store path instead of inside the requested subdirectory.

## Tests
- `nix develop -c pytest tests/test_options.py tests/test_flake_import_path_reset.py`