### PR TITLE
fix: preserve prefixed GitHub release selection

### DIFF
--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -138,21 +138,14 @@ def find_prefixed_version(
     if config.version_prefix == "":
         return None
 
-    ver = next(
-        (
-            Version(
+    for version in final_versions:
+        if version.number.startswith(config.version_prefix):
+            return Version(
                 version.number.removeprefix(config.version_prefix),
                 prerelease=version.prerelease,
                 rev=version.rev or version.number,
             )
-            for version in final_versions
-            if version.number.startswith(config.version_prefix)
-        ),
-        None,
-    )
 
-    if ver is not None and ver.rev != config.old_rev_tag:
-        return ver
     return None
 
 

--- a/tests/test_version_sorting.py
+++ b/tests/test_version_sorting.py
@@ -11,6 +11,7 @@ publishes v0.39.5 after v0.41.1).
 from __future__ import annotations
 
 import io
+import json
 import typing
 import unittest.mock
 import xml.etree.ElementTree as ET
@@ -49,6 +50,25 @@ class _FakeUrlopen:
     ) -> io.BytesIO:
         _ = request, timeout  # satisfy interface contract
         resp = io.BytesIO(self.feed_bytes)
+        resp.status = 200  # type: ignore[attr-defined]
+        return resp
+
+
+class _FakeJsonUrlopen:
+    """Callable that returns a JSON payload for GitHub releases tests."""
+
+    def __init__(self, releases: list[str]) -> None:
+        self.payload = json.dumps(
+            [{"tag_name": tag, "prerelease": False} for tag in releases],
+        ).encode()
+
+    def __call__(
+        self,
+        request: str | Request,
+        timeout: int | None = None,
+    ) -> io.BytesIO:
+        _ = request, timeout  # satisfy interface contract
+        resp = io.BytesIO(self.payload)
         resp.status = 200  # type: ignore[attr-defined]
         return resp
 
@@ -136,3 +156,25 @@ def test_postgis_scenario() -> None:
             ),
         )
         assert version.number == "3.6.0"
+
+
+def test_mixed_prefixed_and_bare_github_releases_keep_prefixed_series() -> None:
+    """Regression test for issue #593."""
+    with unittest.mock.patch(
+        "nix_update.version.github.urllib.request.urlopen",
+        _FakeJsonUrlopen(["v4.10.7", "0.1.0", "0.0.2"]),
+    ):
+        version = fetch_latest_version(
+            urlparse(
+                "https://github.com/zed-industries/vscode-langservers-extracted/archive/v4.10.7.tar.gz",
+            ),
+            VersionFetchConfig(
+                preference=VersionPreference.STABLE,
+                version_regex=r"(.*)",
+                version_prefix="v",
+                old_rev_tag="v4.10.7",
+                fetcher_args={"use_github_releases": True},
+            ),
+        )
+        assert version.number == "4.10.7"
+        assert version.rev == "v4.10.7"


### PR DESCRIPTION
Fixes #593.

## Summary
- preserve the highest matching prefixed release after version sorting
- avoid falling back to bare release tags when the current prefixed tag is already latest
- add regression coverage using the mixed-prefix reproducer from #593

## Testing
- pytest -o addopts='' -q tests/test_version_sorting.py
- pytest -o addopts='' -q tests/test_version_compare.py