### PR TITLE
fix: update npmDepsHash after NPM lockfile generation

### DIFF
--- a/nix_update/dependency_hashes.py
+++ b/nix_update/dependency_hashes.py
@@ -138,6 +138,12 @@ def update_gradle_mitm_cache(opts: Options) -> None:
     run([update_script_path])
 
 
+def update_npm_deps(opts: Options, filename: str, old_hash: str) -> None:
+    if opts.generate_lockfile:
+        generate_lockfile(opts, filename, "npm", opts.get_package())
+    update_hash_with_prefetch("npmDeps", opts, filename, old_hash)
+
+
 def update_dependency_hashes(
     opts: Options,
     package: Package,
@@ -158,9 +164,7 @@ def update_dependency_hashes(
         ),
         "composer_deps": partial(update_hash_with_prefetch, "composerVendor"),
         "composer_deps_old": partial(update_hash_with_prefetch, "composerRepository"),
-        "npm_deps": (lambda o, f, _d: generate_lockfile(o, f, "npm", o.get_package()))
-        if opts.generate_lockfile
-        else partial(update_hash_with_prefetch, "npmDeps"),
+        "npm_deps": update_npm_deps,
         "pnpm_deps": partial(update_hash_with_prefetch, "pnpmDeps"),
         "yarn_deps": partial(update_hash_with_prefetch, "yarnOfflineCache"),
         "yarn_deps_old": partial(update_hash_with_prefetch, "offlineCache"),

--- a/tests/test_npm_lock_generate.py
+++ b/tests/test_npm_lock_generate.py
@@ -47,3 +47,5 @@ def test_update(testpkgs_git: Path) -> None:
     assert (
         "https://github.com/olrtg/emmet-language-server/compare/v2.5.0...v2.6.0" in diff
     )
+    assert "-  npmDepsHash =" in diff
+    assert "+  npmDepsHash =" in diff


### PR DESCRIPTION
This was broken by d0c2d1a3ed5e829e2dec8ec3b41c844935a22735.

Before that commit, `npmDepsHash` was updated whether or not the `--generate-lockfile` option was given.

After that commit, `npmDepsHash` was never updated if the option was given.

I also update the test to detect this failure case.