### PR TITLE
tests: fix test_subpackage

### DIFF
--- a/tests/testpkgs/subpackage.nix
+++ b/tests/testpkgs/subpackage.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   stdenvNoCC,
   nodejs,
-  pnpm_9,
+  pnpm_11,
   typescript,
 }:
 
@@ -23,13 +23,13 @@ let
 
     nativeBuildInputs = [
       nodejs
-      pnpm_9.configHook
+      pnpm_11.configHook
       typescript
     ];
 
     sourceRoot = "${src.name}/web";
 
-    pnpmDeps = pnpm_9.fetchDeps {
+    pnpmDeps = pnpm_11.fetchDeps {
       inherit (autobrr-web)
         pname
         version


### PR DESCRIPTION
the latest autobrr release doesn't work with pnpm 9

https://github.com/Mic92/nix-update/actions/runs/26008063889/job/76443497885