### PR TITLE
update_dependency_hashes: workaround goModules hash depending on other hashes

### DIFF
--- a/nix_update/dependency_hashes.py
+++ b/nix_update/dependency_hashes.py
@@ -170,10 +170,14 @@ def update_dependency_hashes(
     if not (update_hash or not package.hash) or opts.src_only:
         return
 
+    # In theory dependency hashes should only depend on the actual dependencies
+    # being fetched, but some derivation frameworks like goModules pull in the
+    # whole derivation in which case updating other dependencies end up
+    # modifying the hash. Ensure such modules come "later" in order below.
+    # https://github.com/NixOS/nixpkgs/issues/358844
+    # Dictionary iteration order is guaranteed since python 3.7
     hash_updaters: dict[str, Callable[[Options, str, Any], None]] = {
         "fod_subpackage": partial(update_hash_with_prefetch, None),
-        "go_modules": partial(update_hash_with_prefetch, "goModules"),
-        "go_modules_old": partial(update_hash_with_prefetch, "go-modules"),
         "cargo_deps": partial(update_hash_with_prefetch, "cargoDeps"),
         "cargo_vendor_deps": partial(
             update_hash_with_prefetch,
@@ -189,6 +193,8 @@ def update_dependency_hashes(
         "mix_deps": partial(update_hash_with_prefetch, "mixFodDeps"),
         "zig_deps": partial(update_hash_with_prefetch, "zigDeps"),
         "cargo_lock": update_cargo_lock,
+        "go_modules": partial(update_hash_with_prefetch, "goModules"),
+        "go_modules_old": partial(update_hash_with_prefetch, "go-modules"),
     }
 
     # Update all dependency hashes using registry


### PR DESCRIPTION
Some packages like rmfakecloud cannot be reliably updated, this makes the autoupdate script work and create content similar to this PR done manually[1]

This has been discussed in #302 before but the goModules rework that was drafted at that point went stale, and we might as well work around the problem[2] in nix-update: basically, the goModules hash is based on the whole derivation, and not just the actual go dependencies being pulled, so we want to keep it late in execution order.

Link: https://github.com/NixOS/nixpkgs/pull/524309 [1]
Link: https://github.com/NixOS/nixpkgs/issues/358844 [2]
Fixes #302

---------------

Hi! I brought this up for discussion in #302 two years ago and basically we decided back then it's "not our bug", but given there's no fix in sight I think a workaround would make sense.

In theory it's possible this PR could break some other updates using goModules with something else that also has this cyclic dependency problem, but if there were such other modules then they'd never possibly settle on a valid hash (updating go would update the other's hash, and in turn updating that other's hash would update go's), so I'm pretty confident this shouldn't break anything.
It's just ugly and not mentally satisfying.

(cc @coolGi69 as he's spent time looking at it again recently - thank you!)