### PR TITLE
github: paginate releases

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -156,6 +156,12 @@ def parse_args(args: list[str]) -> Options:
         help="Use GitHub releases API instead of ATOM feed to determine the newest version",
     )
     parser.add_argument(
+        "--github-releases-limit",
+        type=int,
+        default=1000,
+        help="Maximum number of GitHub releases to consider (default: %(default)s)",
+    )
+    parser.add_argument(
         "--option",
         help="Nix option to set",
         action="append",
@@ -205,6 +211,7 @@ def parse_args(args: list[str]) -> Options:
         lockfile_metadata_path=a.lockfile_metadata_path,
         src_only=a.src_only,
         use_github_releases=a.use_github_releases,
+        github_releases_limit=a.github_releases_limit,
         extra_flags=extra_flags,
         update_src=not a.no_src,
         custom_deps=a.custom_dep,

--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -138,6 +138,7 @@ class Options:
     src_only: bool = False
     update_src: bool = True
     use_github_releases: bool = False
+    github_releases_limit: int = 1000
     extra_flags: list[str] = field(default_factory=list)
     custom_deps: list[str] | None = None
 

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -100,7 +100,10 @@ def fetch_new_version(
         branch=branch,
         old_rev_tag=old_rev_tag,
         version_prefix=version_prefix,
-        fetcher_args={"use_github_releases": opts.use_github_releases},
+        fetcher_args={
+            "use_github_releases": opts.use_github_releases,
+            "github_releases_limit": opts.github_releases_limit,
+        },
     )
     return fetch_latest_version(package.parsed_url, config)
 

--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -86,35 +86,49 @@ def fetch_github_versions(
         return []
     owner, repo = urlmatch.group("owner"), urlmatch.group("repo")
     if extra_args is not None and extra_args.get("use_github_releases"):
-        return fetch_github_versions_from_releases(url, owner, repo)
+        limit = extra_args.get("github_releases_limit", DEFAULT_RELEASES_LIMIT)
+        return fetch_github_versions_from_releases(url, owner, repo, limit)
     return fetch_github_versions_from_feed(url, owner, repo)
+
+
+# Bounds API usage on repos with thousands of releases.
+DEFAULT_RELEASES_LIMIT = 1000
+RELEASES_PER_PAGE = 100
 
 
 def fetch_github_versions_from_releases(
     url: ParseResult,
     owner: str,
     repo: str,
+    limit: int = DEFAULT_RELEASES_LIMIT,
 ) -> list[Version]:
-    github_url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100"
+    api_base = f"https://api.github.com/repos/{owner}/{repo}"
     if url.netloc not in {"github.com", "api.github.com"}:
-        github_url = (
-            f"https://{url.netloc}/api/v3/repos/{owner}/{repo}/releases?per_page=100"
-        )
+        api_base = f"https://{url.netloc}/api/v3/repos/{owner}/{repo}"
 
-    # TODO: pagination?
     token = os.environ.get("GITHUB_TOKEN")
     extra_headers = {} if token is None else {"Authorization": f"Bearer {token}"}
 
-    info(f"fetch {github_url}")
-    resp = _dorequest(url, github_url, extra_headers)
-    if resp is None:
-        return []
-    try:
-        releases = json.loads(resp)
-    except json.JSONDecodeError:
-        info("unable to parse github response, ignoring")
-        return []
-    return [Version(r["tag_name"], r["prerelease"]) for r in releases]
+    # Releases are ordered by creation date, not version, so the wanted
+    # release can sit on any page.
+    versions: list[Version] = []
+    page = 1
+    while len(versions) < limit:
+        github_url = f"{api_base}/releases?per_page={RELEASES_PER_PAGE}&page={page}"
+        info(f"fetch {github_url}")
+        resp = _dorequest(url, github_url, extra_headers)
+        if resp is None:
+            break
+        try:
+            releases = json.loads(resp)
+        except json.JSONDecodeError:
+            info("unable to parse github response, ignoring")
+            break
+        versions.extend(Version(r["tag_name"], r["prerelease"]) for r in releases)
+        if len(releases) < RELEASES_PER_PAGE:
+            break
+        page += 1
+    return versions
 
 
 def fetch_github_versions_from_feed(

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -21,7 +21,7 @@ def fake_urlopen(req: Request, timeout: float | None = None) -> BinaryIO:
     url = req.get_full_url()
     if url.endswith("releases.atom"):
         return TEST_ROOT.joinpath("test_branch_releases.atom").open("rb")
-    if url.endswith("/releases?per_page=100"):
+    if "/releases?per_page=100" in url:
         return TEST_ROOT.joinpath("test_branch_releases.json").open("rb")
     return TEST_ROOT.joinpath("test_branch_commits_master.atom").open("rb")
 

--- a/tests/test_github_releases_pagination.py
+++ b/tests/test_github_releases_pagination.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import unittest.mock
+from io import BytesIO
+from typing import TYPE_CHECKING, BinaryIO
+from urllib.parse import parse_qs, urlparse
+
+from nix_update.version import VersionFetchConfig, fetch_latest_version
+from nix_update.version.version import VersionPreference
+
+if TYPE_CHECKING:
+    from urllib.request import Request
+
+    from tests import conftest
+
+# Page 1 contains only prereleases, the stable release is on page 2.
+PAGES = {
+    1: [{"tag_name": f"v1.6.6-rc.{n}", "prerelease": True} for n in range(154, 54, -1)],
+    2: [{"tag_name": "v1.6.5", "prerelease": False}],
+}
+
+
+def test_paginates_past_prerelease_only_page(helpers: conftest.Helpers) -> None:
+    del helpers
+    requests: list[str] = []
+
+    def fake_urlopen(req: Request, timeout: float | None = None) -> BinaryIO:
+        del timeout  # Unused in test
+        requests.append(req.get_full_url())
+        page = int(parse_qs(urlparse(req.get_full_url()).query)["page"][0])
+        return BytesIO(json.dumps(PAGES.get(page, [])).encode())
+
+    with unittest.mock.patch("urllib.request.urlopen", fake_urlopen):
+        version = fetch_latest_version(
+            urlparse("https://github.com/abhigyanpatwari/GitNexus"),
+            VersionFetchConfig(
+                preference=VersionPreference.STABLE,
+                version_regex="v(.*)",
+                fetcher_args={"use_github_releases": True},
+            ),
+        )
+    assert version.number == "1.6.5"
+    # Page 2 is short, so pagination stops before the cap.
+    assert len(requests) == len(PAGES)
+
+
+def test_releases_limit(helpers: conftest.Helpers) -> None:
+    del helpers
+    requests: list[str] = []
+
+    def fake_urlopen(req: Request, timeout: float | None = None) -> BinaryIO:
+        del timeout  # Unused in test
+        requests.append(req.get_full_url())
+        page = int(parse_qs(urlparse(req.get_full_url()).query)["page"][0])
+        return BytesIO(json.dumps(PAGES.get(page, [])).encode())
+
+    with unittest.mock.patch("urllib.request.urlopen", fake_urlopen):
+        version = fetch_latest_version(
+            urlparse("https://github.com/abhigyanpatwari/GitNexus"),
+            VersionFetchConfig(
+                preference=VersionPreference.UNSTABLE,
+                version_regex="v(.*)",
+                fetcher_args={
+                    "use_github_releases": True,
+                    "github_releases_limit": 100,
+                },
+            ),
+        )
+    assert version.number == "1.6.6-rc.154"
+    assert len(requests) == 1


### PR DESCRIPTION
I ran into this with GitNexus: upstream tagged hundreds of v1.6.6-rc.NNN prereleases, so the first releases page is all prereleases and nix-update fails with VersionError even though a stable release exists.

We only fetched the first page of /releases (there was even a "TODO: pagination?" comment). Since releases are sorted by creation date and not by version, the release we want can be on any page - also when a backport gets published after a newer stable.

Now we paginate until we run out of releases, capped at 1000 to not hammer the API on repos with huge release counts. The cap can be changed with --github-releases-limit.