### PR TITLE
fix: handle subdirectory flakes in get_flake_store_path

### DIFF
--- a/nix_update/options.py
+++ b/nix_update/options.py
@@ -5,6 +5,7 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 from .errors import AttributePathError
 from .version.version import VersionPreference
@@ -94,6 +95,12 @@ def get_flake_store_path(import_path: str) -> str | None:
     Uses ``nix flake metadata`` so that git-ignored files are excluded and
     only tracked content is copied.  Returns *None* when the command fails
     (e.g. the directory is not a flake).
+
+    For subdirectory flakes (where the flake lives in a subdirectory of a git
+    repo), nix copies the entire git tree into the store and reports the root
+    as ``path``.  We detect this via the ``dir`` query parameter in the
+    resolved URL and append it so that ``builtins.getFlake`` finds the
+    ``flake.nix`` at the correct location.
     """
     try:
         result = subprocess.run(
@@ -104,7 +111,17 @@ def get_flake_store_path(import_path: str) -> str | None:
             check=True,
         )
         metadata = json.loads(result.stdout)
-        return metadata.get("path")
+        path = metadata.get("path")
+        if path is None:
+            return None
+        # Handle subdirectory flakes: the store path points to the git root,
+        # but the flake.nix lives in a subdirectory indicated by ?dir=...
+        resolved_url = metadata.get("resolvedUrl", "")
+        parsed = urlparse(resolved_url)
+        dir_params = parse_qs(parsed.query).get("dir")
+        if dir_params:
+            path = str(Path(path) / dir_params[0])
+        return path
     except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError):
         return None
 

--- a/tests/test_flake_subdir.py
+++ b/tests/test_flake_subdir.py
@@ -1,0 +1,129 @@
+"""Test that subdirectory flakes are handled correctly.
+
+Regression test for https://github.com/Mic92/nix-update/issues/534
+When a flake lives in a subdirectory of a git repo (using ?dir=...),
+nix flake metadata reports the git root as ``path`` but the flake.nix
+lives in a subdirectory.  get_flake_store_path must append the dir
+component so that builtins.getFlake can find the flake.nix.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from nix_update.options import get_flake_store_path
+
+if TYPE_CHECKING:
+    pass
+
+
+def test_get_flake_store_path_appends_dir_for_subdir_flakes() -> None:
+    """get_flake_store_path appends the dir query param from resolvedUrl."""
+    fake_metadata = {
+        "path": "/nix/store/abc123-source",
+        "resolvedUrl": "git+file:///home/user/repo?dir=pkgs/my-flake",
+    }
+    fake_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(fake_metadata),
+        stderr="",
+    )
+    with patch("subprocess.run", return_value=fake_result):
+        result = get_flake_store_path("/home/user/repo/pkgs/my-flake")
+    assert result == "/nix/store/abc123-source/pkgs/my-flake"
+
+
+def test_get_flake_store_path_no_dir_param() -> None:
+    """get_flake_store_path returns path as-is when there is no dir param."""
+    fake_metadata = {
+        "path": "/nix/store/abc123-source",
+        "resolvedUrl": "git+file:///home/user/repo",
+    }
+    fake_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(fake_metadata),
+        stderr="",
+    )
+    with patch("subprocess.run", return_value=fake_result):
+        result = get_flake_store_path("/home/user/repo")
+    assert result == "/nix/store/abc123-source"
+
+
+def test_get_flake_store_path_no_resolved_url() -> None:
+    """get_flake_store_path handles missing resolvedUrl gracefully."""
+    fake_metadata = {
+        "path": "/nix/store/abc123-source",
+    }
+    fake_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(fake_metadata),
+        stderr="",
+    )
+    with patch("subprocess.run", return_value=fake_result):
+        result = get_flake_store_path("/home/user/repo")
+    assert result == "/nix/store/abc123-source"
+
+
+@pytest.mark.skipif(
+    shutil.which("nix") is None,
+    reason="nix not available",
+)
+def test_get_flake_store_path_integration_subdir() -> None:
+    """Integration test: a flake in a git subdirectory gets the correct store path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        subdir = root / "sub" / "flake"
+        subdir.mkdir(parents=True)
+
+        # Create a minimal flake in the subdirectory
+        (subdir / "flake.nix").write_text(
+            '{ outputs = { self }: { }; }\n'
+        )
+
+        # Initialize git repo at root
+        subprocess.run(["git", "init", str(root)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(root), "add", "--all"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.name", "test"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "commit.gpgsign", "false"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+
+        result = get_flake_store_path(str(subdir))
+        assert result is not None
+        # The result should end with the subdirectory path
+        assert result.endswith("/sub/flake"), f"Expected path ending with /sub/flake, got: {result}"
+        # And should point to a valid nix store path
+        assert result.startswith("/nix/store/")
+        # And should contain a flake.nix
+        assert Path(result, "flake.nix").exists()


### PR DESCRIPTION
When a flake lives in a subdirectory of a git repo (e.g. using `nix-update --flake -f ./some/subdir pkg`), `nix flake metadata` reports the git root as the store `path`, not the subdirectory containing flake.nix. This causes `builtins.getFlake` to fail with "path .../flake.nix does not exist".

This PR fixes this issue by parsing the `dir` query parameter from `resolvedUrl` and appending it to the store path, so the flake reference points to the correct subdirectory.

Fixes #534.