### PR TITLE
nuget: support flake-based repositories

### DIFF
--- a/nix_update/dependency_hashes.py
+++ b/nix_update/dependency_hashes.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import tempfile
 from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -107,33 +108,49 @@ def update_hash_with_prefetch(
 update_src_hash = partial(update_hash_with_prefetch, "src")
 
 
-def update_nuget_deps(opts: Options) -> None:
-    """Update NuGet dependencies."""
-    fetch_deps_script_path = run(
+def build_package_attr(opts: Options, attr: str) -> str:
+    """Build a package attribute and return the resulting store path.
+
+    Uses ``opts.get_package()`` instead of ``nix-build -A`` because flake
+    repositories may not have a default.nix.
+    """
+    return run(
         [
             "nix-build",
-            opts.import_path,
-            "-A",
-            f"{opts.attribute}.fetch-deps",
+            "--expr",
+            f"{opts.get_package()}.{attr}",
             "--no-out-link",
+            *opts.extra_flags,
         ],
     ).stdout.strip()
 
-    # Run the fetch-deps script without arguments - it determines the path itself
-    run([fetch_deps_script_path])
+
+def update_nuget_deps(opts: Options) -> None:
+    """Update NuGet dependencies."""
+    fetch_deps_script_path = build_package_attr(opts, "fetch-deps")
+
+    cmd = [fetch_deps_script_path]
+    flake_src = opts.get_flake_import_path()
+    if flake_src is not None:
+        # The script's default deps file points into the read-only store copy
+        # of the flake source; redirect it to the local checkout.
+        match = re.search(
+            r"^defaultDepsFile=(.*)$",
+            Path(fetch_deps_script_path).read_text(),
+            re.MULTILINE,
+        )
+        deps_file = match.group(1).strip("'\"") if match else ""
+        prefix = flake_src.rstrip("/") + "/"
+        if deps_file.startswith(prefix):
+            cmd.append(str(Path(opts.import_path) / deps_file.removeprefix(prefix)))
+
+    # Without an argument the script writes to its default deps file
+    run(cmd)
 
 
 def update_gradle_mitm_cache(opts: Options) -> None:
     """Update Gradle dependencies."""
-    update_script_path = run(
-        [
-            "nix-build",
-            opts.import_path,
-            "-A",
-            f"{opts.attribute}.mitmCache.updateScript",
-            "--no-out-link",
-        ],
-    ).stdout.strip()
+    update_script_path = build_package_attr(opts, "mitmCache.updateScript")
 
     run([update_script_path])
 

--- a/tests/test_nuget_deps_flake.py
+++ b/tests/test_nuget_deps_flake.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+from nix_update import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_update(testpkgs_git: Path) -> None:
+    # Regression: flake repos need not ship a default.nix; the fetch-deps
+    # script must be built through the flake, not via `nix-build -A`.
+    (testpkgs_git / "default.nix").unlink()
+    subprocess.run(
+        ["git", "-C", str(testpkgs_git), "commit", "-am", "remove default.nix"],
+        check=True,
+    )
+    main(
+        [
+            "--file",
+            str(testpkgs_git),
+            "--flake",
+            "--commit",
+            "nuget-deps-generate",
+            "--version",
+            "v1.1.1",
+        ],
+    )
+
+    nuget_deps_raw = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            "--extra-experimental-features",
+            "flakes nix-command",
+            f"{testpkgs_git}#nuget-deps-generate.nugetDeps",
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+    nuget_deps = json.loads(nuget_deps_raw)
+    assert len(nuget_deps) > 0
+
+    diff = subprocess.run(
+        ["git", "-C", str(testpkgs_git), "show"],
+        text=True,
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout.strip()
+    print(diff)
+    assert "https://github.com/ExOK/Celeste64/compare/v1.1.0...v1.1.1" in diff
+    assert "nuget-deps-generate/deps.json" in diff

--- a/tests/testpkgs/flake.nix
+++ b/tests/testpkgs/flake.nix
@@ -15,6 +15,9 @@
         flake-use-update-script = nixpkgs.legacyPackages.${system}.callPackage (
           self + "/flake-use-update-script.nix"
         ) { };
+        nuget-deps-generate = nixpkgs.legacyPackages.${system}.callPackage (
+          self + "/nuget-deps-generate"
+        ) { };
       });
     };
 }


### PR DESCRIPTION
Updating nugetDeps or a gradle mitmCache in a flake-only repo failed with:

```
error: path '.../default.nix' does not exist
```

because the update script was built with `nix-build <import-path> -A`. Build it through `Options.get_package()` instead, which handles both flake and non-flake repos.

For flakes the fetch-deps script's default deps file points into the read-only store copy of the source, so pass the corresponding path in the local checkout as argument.