### PR TITLE
ci: switch binary cache from cachix to hestia

### DIFF
--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -1,0 +1,33 @@
+# Garbage collection for the hestia binary cache. Must run on the default
+# branch: PR cache scopes die with the PR, the default-branch scope grows
+# forever without GC.
+name: Cache GC
+# A concurrent GC races another GC's pack deletes; queue runs instead.
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+on:
+  schedule:
+    - cron: "23 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Plan only; do not repack, touch, or delete anything.
+        type: boolean
+        default: false
+permissions:
+  contents: read
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    permissions:
+      # REST cache deletes need actions:write.
+      actions: write
+      contents: read
+    steps:
+      - uses: cachix/install-nix-action@v31
+      - uses: Mic92/hestia/action@main
+      - name: Run garbage collection
+        run: '"$HESTIA_BIN" gc ${{ inputs.dry-run && ''--dry-run'' || '''' }}'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v17
-        with:
-          name: nix-update
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: Mic92/hestia/action@main
       - name: build
         run: nix build
       - name: Allow unprivileged user namespaces


### PR DESCRIPTION

Cachix needs an account and an auth token secret, so PRs from forks
ran without any cache. Hestia stores build results in the GitHub
Actions cache and authenticates with the runner-injected token, which
also works for contributor PRs. Add a weekly GC workflow to stay
within the 10 GB cache quota.
