### PR TITLE
ci: root test toolchains in the hestia cache

### DIFF
--- a/.github/workflows/cache-test-deps.yml
+++ b/.github/workflows/cache-test-deps.yml
@@ -1,0 +1,23 @@
+# Hestia only uploads runtime closures, so test-fixture toolchains
+# (rust, maturin, jq) need an explicit root to get cached.
+name: Cache test deps
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - staging
+      - trying
+permissions:
+  contents: read
+jobs:
+  cache-test-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: Mic92/hestia/action@main
+      - run: nix build --no-link .#checks.x86_64-linux.test-deps

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,21 @@
                 packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages;
                 devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
               in
-              packages // devShells;
+              packages
+              // devShells
+              // {
+                # Puts test-fixture toolchains in a runtime closure so the
+                # CI binary cache (hestia) roots them.
+                test-deps = pkgs.linkFarm "test-deps" {
+                  inherit (pkgs)
+                    rustc
+                    cargo
+                    cargo-auditable
+                    maturin
+                    jq
+                    ;
+                };
+              };
           };
       }
     );


### PR DESCRIPTION

Hestia only uploads runtime closures, so toolchains used by test
fixture builds (rust, maturin, jq) were re-fetched from
cache.nixos.org every run. Build a test-deps linkFarm in its own
workflow to root them in the cache.
