### PR TITLE
flake: drop flake-parts dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780930886,
@@ -38,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,74 +3,80 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
-    inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } (
-      { lib, ... }:
-      {
-        imports = [ ./treefmt.nix ];
-        systems = [
-          "aarch64-linux"
-          "x86_64-linux"
-          "riscv64-linux"
+    {
+      self,
+      nixpkgs,
+      treefmt-nix,
+    }:
+    let
+      inherit (nixpkgs) lib;
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "riscv64-linux"
 
-          "x86_64-darwin"
-          "aarch64-darwin"
-        ];
-        perSystem =
-          {
-            config,
-            pkgs,
-            self',
-            ...
-          }:
-          {
-            packages.nix-update = pkgs.callPackage ./. { };
-            packages.default = config.packages.nix-update;
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+      treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
+    in
+    {
+      packages = eachSystem (pkgs: rec {
+        nix-update = pkgs.callPackage ./. { };
+        default = nix-update;
+      });
 
-            devShells.default = pkgs.mkShell {
-              inputsFrom = [ config.packages.default ];
-              packages = [
-                (pkgs.python3.withPackages (
-                  ps: with ps; [
-                    pytest
-                  ]
-                ))
-                pkgs.mypy
-                pkgs.ruff
-              ];
-              # Make tests use our pinned Nixpkgs
-              env.NIX_PATH = "nixpkgs=${pkgs.path}";
-            };
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+          packages = [
+            (pkgs.python3.withPackages (
+              ps: with ps; [
+                pytest
+              ]
+            ))
+            pkgs.mypy
+            pkgs.ruff
+          ];
+          # Make tests use our pinned Nixpkgs
+          env.NIX_PATH = "nixpkgs=${pkgs.path}";
+        };
+      });
 
-            checks =
-              let
-                packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages;
-                devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
-              in
-              packages
-              // devShells
-              // {
-                # Puts test-fixture toolchains in a runtime closure so the
-                # CI binary cache (hestia) roots them.
-                test-deps = pkgs.linkFarm "test-deps" {
-                  inherit (pkgs)
-                    rustc
-                    cargo
-                    cargo-auditable
-                    maturin
-                    jq
-                    ;
-                };
-              };
+      formatter = eachSystem (pkgs: treefmtEval.${pkgs.stdenv.hostPlatform.system}.config.build.wrapper);
+
+      checks = eachSystem (
+        pkgs:
+        let
+          system = pkgs.stdenv.hostPlatform.system;
+          packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self.packages.${system};
+          devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self.devShells.${system};
+        in
+        packages
+        // devShells
+        // lib.optionalAttrs (system != "riscv64-linux") {
+          formatting = treefmtEval.${system}.config.build.check self;
+        }
+        // {
+          # Puts test-fixture toolchains in a runtime closure so the
+          # CI binary cache (hestia) roots them.
+          test-deps = pkgs.linkFarm "test-deps" {
+            inherit (pkgs)
+              rustc
+              cargo
+              cargo-auditable
+              maturin
+              jq
+              ;
           };
-      }
-    );
+        }
+      );
+    };
 }

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,39 +1,29 @@
-{ inputs, ... }:
+{ pkgs, ... }:
 {
-  imports = [ inputs.treefmt-nix.flakeModule ];
+  # Used to find the project root
+  projectRootFile = "flake.lock";
 
-  perSystem =
-    { pkgs, ... }:
-    {
-      treefmt = {
-        flakeCheck = pkgs.stdenv.hostPlatform.system != "riscv64-linux";
+  # Ignore these files
+  settings.excludes = [ "tests/testpkgs/custom-deps/pnpm/pnpm-lock.yaml" ];
 
-        # Used to find the project root
-        projectRootFile = "flake.lock";
-
-        # Ignore these files
-        settings.excludes = [ "tests/testpkgs/custom-deps/pnpm/pnpm-lock.yaml" ];
-
-        programs.deno.enable = pkgs.stdenv.hostPlatform.system != "x86_64-darwin";
-        programs.mypy.enable = true;
-        programs.mypy.directories = {
-          "." = {
-            extraPythonPackages = with pkgs.python3.pkgs; [
-              pytest
-            ];
-          };
-        };
-
-        programs.yamlfmt.enable = true;
-
-        programs.nixfmt.enable = true;
-        programs.deadnix.enable = true;
-        programs.ruff.format = true;
-        programs.ruff.check = true;
-
-        programs.shellcheck.enable = true;
-        programs.shfmt.enable = true;
-        settings.formatter.shfmt.includes = [ "*.envrc" ];
-      };
+  programs.deno.enable = pkgs.stdenv.hostPlatform.system != "x86_64-darwin";
+  programs.mypy.enable = true;
+  programs.mypy.directories = {
+    "." = {
+      extraPythonPackages = with pkgs.python3.pkgs; [
+        pytest
+      ];
     };
+  };
+
+  programs.yamlfmt.enable = true;
+
+  programs.nixfmt.enable = true;
+  programs.deadnix.enable = true;
+  programs.ruff.format = true;
+  programs.ruff.check = true;
+
+  programs.shellcheck.enable = true;
+  programs.shfmt.enable = true;
+  settings.formatter.shfmt.includes = [ "*.envrc" ];
 }


### PR DESCRIPTION

flake-parts adds an extra input and indirection layer for what is a
simple per-system flake. Replace it with plain genAttrs over the
supported systems and evaluate treefmt-nix directly via evalModule,
keeping the formatter, formatting check and all existing outputs.
