### PR TITLE
gitlab: authenticate API requests with GITLAB_TOKEN

### DIFF
--- a/nix_update/version/gitlab.py
+++ b/nix_update/version/gitlab.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from datetime import datetime
 from urllib.parse import ParseResult, quote_plus
@@ -15,6 +16,11 @@ GITLAB_API = re.compile(
 )
 
 
+def gitlab_headers() -> dict[str, str]:
+    token = os.environ.get("GITLAB_TOKEN")
+    return {} if token is None else {"Authorization": f"Bearer {token}"}
+
+
 def fetch_gitlab_versions(url: ParseResult) -> list[Version]:
     match = GITLAB_API.match(url.geturl())
     if not match:
@@ -23,7 +29,7 @@ def fetch_gitlab_versions(url: ParseResult) -> list[Version]:
     project_id = match.group("project_id")
     gitlab_url = f"https://{domain}/api/v4/projects/{project_id}/repository/tags"
     info(f"fetch {gitlab_url}")
-    json_tags = fetch_json(gitlab_url)
+    json_tags = fetch_json(gitlab_url, headers=gitlab_headers())
     if len(json_tags) == 0:
         msg = "No git tags found"
         raise VersionError(msg)
@@ -53,7 +59,7 @@ def fetch_gitlab_snapshots(url: ParseResult, branch: str) -> list[Version]:
     project_id = match.group("project_id")
     gitlab_url = f"https://{domain}/api/v4/projects/{project_id}/repository/commits?ref_name={quote_plus(branch)}"
     info(f"fetch {gitlab_url}")
-    commits = fetch_json(gitlab_url)
+    commits = fetch_json(gitlab_url, headers=gitlab_headers())
 
     try:
         versions = fetch_gitlab_versions(url)

--- a/nix_update/version/http.py
+++ b/nix_update/version/http.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 if TYPE_CHECKING:
     from typing import Any
@@ -16,7 +16,9 @@ DEFAULT_TIMEOUT = 60
 def fetch_json(
     url: str,
     timeout: int = DEFAULT_TIMEOUT,
+    headers: dict[str, str] | None = None,
 ) -> Any:  # noqa: ANN401
     """Fetch JSON data from a URL with proper timeout and error handling."""
-    with urlopen(url, timeout=timeout) as resp:
+    request = Request(url, headers=headers or {})
+    with urlopen(request, timeout=timeout) as resp:
         return json.load(resp)

--- a/tests/test_gitlab_fetch_latest_version.py
+++ b/tests/test_gitlab_fetch_latest_version.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest.mock
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import pytest
+
+from nix_update.version import VersionFetchConfig, fetch_latest_version
+from nix_update.version.version import VersionPreference
+
+if TYPE_CHECKING:
+    from urllib.request import Request
+
+TARBALL_URL = (
+    "https://gitlab.com/api/v4/projects/42/repository/archive.tar.gz?sha=v1.0.0"
+)
+TAGS_URL = "https://gitlab.com/api/v4/projects/42/repository/tags"
+
+TAGS_RESPONSE = json.dumps([{"name": "v1.1.0"}, {"name": "v1.0.0"}]).encode()
+
+
+@pytest.mark.parametrize(
+    ("env", "expected_auth"),
+    [
+        ({}, None),
+        ({"GITLAB_TOKEN": "secret123"}, "Bearer secret123"),
+    ],
+)
+def test_gitlab_token(env: dict[str, str], expected_auth: str | None) -> None:
+    seen_headers: dict[str, str] = {}
+
+    def fake_urlopen(request: Request, timeout: float | None = None) -> io.BytesIO:
+        del timeout  # Unused in test
+        seen_headers.update(request.headers)
+        assert request.full_url == TAGS_URL
+        return io.BytesIO(TAGS_RESPONSE)
+
+    with (
+        unittest.mock.patch("nix_update.version.http.urlopen", fake_urlopen),
+        unittest.mock.patch.dict("os.environ", env, clear=True),
+    ):
+        version = fetch_latest_version(
+            urlparse(TARBALL_URL),
+            VersionFetchConfig(
+                preference=VersionPreference.STABLE,
+                version_regex="(.*)",
+            ),
+        )
+    assert version.number == "v1.1.0"
+    assert seen_headers.get("Authorization") == expected_auth

--- a/tests/test_npm_fetch_latest_version.py
+++ b/tests/test_npm_fetch_latest_version.py
@@ -9,11 +9,14 @@ from nix_update.version import VersionFetchConfig, fetch_latest_version
 from nix_update.version.version import VersionPreference
 
 if TYPE_CHECKING:
+    from urllib.request import Request
+
     from tests import conftest
 
 
-def fake_npm_urlopen(url: str, timeout: float | None = None) -> io.BytesIO:
+def fake_npm_urlopen(request: Request, timeout: float | None = None) -> io.BytesIO:
     del timeout  # Unused in test
+    url = request.full_url
     if url == "https://registry.npmjs.org/@anthropic-ai/claude-code/latest":
         return io.BytesIO(b'{"version": "1.0.43"}')
 


### PR DESCRIPTION
GitLab rate-limits unauthenticated API requests. Honor `GITLAB_TOKEN`, like the existing `GITHUB_TOKEN` support, by letting `fetch_json` send headers.

Supersedes #580 with tests and lint fixes.