### PR TITLE
create-release: enforce version format without v prefix

### DIFF
--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -11,6 +11,13 @@ if [[ -z $version ]]; then
   exit 1
 fi
 
+# version must be plain semver without "v" prefix; tag gets "v" added below
+if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "version must match X.Y.Z without 'v' prefix, got: ${version}" >&2
+  exit 1
+fi
+tag="v${version}"
+
 if [[ "$(git symbolic-ref --short HEAD)" != "main" ]]; then
   echo "must be on main branch" >&2
   exit 1
@@ -40,8 +47,8 @@ if [[ $unpushed_commits != "" ]]; then
   exit 1
 fi
 # make sure tag does not exist
-if git tag -l | grep -q "^${version}\$"; then
-  echo "Tag ${version} already exists, exiting" >&2
+if git tag -l | grep -q "^${tag}\$"; then
+  echo "Tag ${tag} already exists, exiting" >&2
   exit 1
 fi
 sed -i -e "s!version = \".*\";!version = \"${version}\";!" default.nix
@@ -67,4 +74,4 @@ git checkout main
 
 waitForPr "release-${version}"
 git pull git@github.com:Mic92/nix-update main
-gh release create "${version}" --draft --title "${version}" --notes ""
+gh release create "${tag}" --draft --title "${tag}" --notes ""

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -51,10 +51,8 @@ if git tag -l | grep -q "^${tag}\$"; then
   echo "Tag ${tag} already exists, exiting" >&2
   exit 1
 fi
-sed -i -e "s!version = \".*\";!version = \"${version}\";!" default.nix
 sed -i -e "s!^version = \".*\"\$!version = \"${version}\"!" pyproject.toml
-echo "VERSION = \"${version}\"" >nix_update/version_info.py
-git add pyproject.toml default.nix nix_update/version_info.py
+git add pyproject.toml
 git branch -D "release-${version}" || true
 git checkout -b "release-${version}"
 git commit -m "bump version ${version}"

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 }:
 pkgs.python3Packages.buildPythonApplication {
   pname = "nix-update";
-  version = "v1.15.1";
+  version = "1.15.1";
   src = ./.;
   pyproject = true;
   buildInputs = [ pkgs.makeWrapper ];

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 }:
 pkgs.python3Packages.buildPythonApplication {
   pname = "nix-update";
-  version = "1.15.1";
+  version = (pkgs.lib.importTOML ./pyproject.toml).project.version;
   src = ./.;
   pyproject = true;
   buildInputs = [ pkgs.makeWrapper ];

--- a/nix_update/version_info.py
+++ b/nix_update/version_info.py
@@ -1,1 +1,19 @@
-VERSION = "1.15.1"
+import tomllib
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _version() -> str:
+    try:
+        return version("nix-update")
+    except PackageNotFoundError:
+        # running from a source checkout without installed metadata
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        try:
+            with pyproject.open("rb") as f:
+                return str(tomllib.load(f)["project"]["version"])
+        except OSError:
+            return "unknown"
+
+
+VERSION = _version()

--- a/nix_update/version_info.py
+++ b/nix_update/version_info.py
@@ -1,1 +1,1 @@
-VERSION = "v1.15.1"
+VERSION = "1.15.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nix-update"
 description = "Swiss-knife for updating nix packages"
-version = "v1.15.1"
+version = "1.15.1"
 authors = [{ name = "Jörg Thalheim", email = "joerg@thalheim.io" }]
 license = { text = "MIT" }
 classifiers = [


### PR DESCRIPTION

Past releases mixed tags with and without v prefix because the version
argument was used verbatim for both Python packaging metadata and the git
tag. Validate that the version is plain X.Y.Z and derive the tag as
v${version}, so packaging files stay unprefixed while tags are
consistently prefixed. Also strip the stray v prefix that slipped into
the 1.15.1 version metadata.
