### PR TITLE
ci: switch to Mic92/hestia@v1

### DIFF
--- a/.github/workflows/cache-test-deps.yml
+++ b/.github/workflows/cache-test-deps.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia@v1
       - run: nix build --no-link .#checks.x86_64-linux.test-deps

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - uses: cachix/install-nix-action@v31
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia@v1
       - name: Run garbage collection
         run: '"$HESTIA_BIN" gc ${{ inputs.dry-run && ''--dry-run'' || '''' }}'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia/action@main
+      - uses: Mic92/hestia@v1
       - name: build
         run: nix build
       - name: Allow unprivileged user namespaces


### PR DESCRIPTION
Hestia [v1.0](https://github.com/Mic92/hestia/releases/tag/v1.0.2) moved action.yml to the repo root, so the path shortens from `Mic92/hestia/action@main` to `Mic92/hestia@v1`. Tracks the floating major tag for automatic 1.x updates.