### PR TITLE
add support for npm dist-tags using the branch version for npm packages

### DIFF
--- a/nix_update/version/__init__.py
+++ b/nix_update/version/__init__.py
@@ -18,7 +18,7 @@ from .crate import fetch_crate_versions
 from .gitea import fetch_gitea_snapshots, fetch_gitea_versions
 from .github import fetch_github_snapshots, fetch_github_versions
 from .gitlab import fetch_gitlab_snapshots, fetch_gitlab_versions
-from .npm import fetch_npm_versions
+from .npm import fetch_npm_snapshots, fetch_npm_versions
 from .pypi import fetch_pypi_versions
 from .rubygems import fetch_rubygem_versions
 from .savannah import fetch_savannah_versions
@@ -78,6 +78,7 @@ fetchers: list[Fetcher] = [
 ]
 
 branch_snapshots_fetchers: list[SnapshotFetcher] = [
+    fetch_npm_snapshots,
     fetch_github_snapshots,
     fetch_gitlab_snapshots,
     fetch_bitbucket_snapshots,

--- a/nix_update/version/npm.py
+++ b/nix_update/version/npm.py
@@ -11,25 +11,21 @@ if TYPE_CHECKING:
     from urllib.parse import ParseResult
 
 
-def fetch_npm_versions(url: ParseResult) -> list[Version]:
+def _fetch_npm_dist_tag(url: ParseResult, dist_tag: str) -> list[Version]:
     if url.netloc != "registry.npmjs.org":
         return []
     parts = url.path.split("/")
     # Handle scoped packages like @myorg/mypackage
     package = f"{parts[1]}/{parts[2]}" if parts[1].startswith("@") else parts[1]
-    npm_url = f"https://registry.npmjs.org/{package}/latest"
+    npm_url = f"https://registry.npmjs.org/{package}/{dist_tag}"
     info(f"fetch {npm_url}")
     data = fetch_json(npm_url)
     return [Version(data["version"])]
+
+
+def fetch_npm_versions(url: ParseResult) -> list[Version]:
+    return _fetch_npm_dist_tag(url, "latest")
 
 
 def fetch_npm_snapshots(url: ParseResult, branch: str) -> list[Version]:
-    if url.netloc != "registry.npmjs.org":
-        return []
-    parts = url.path.split("/")
-    # Handle scoped packages like @myorg/mypackage
-    package = f"{parts[1]}/{parts[2]}" if parts[1].startswith("@") else parts[1]
-    npm_url = f"https://registry.npmjs.org/{package}/{branch}"
-    info(f"fetch {npm_url}")
-    data = fetch_json(npm_url)
-    return [Version(data["version"])]
+    return _fetch_npm_dist_tag(url, branch)

--- a/nix_update/version/npm.py
+++ b/nix_update/version/npm.py
@@ -21,3 +21,15 @@ def fetch_npm_versions(url: ParseResult) -> list[Version]:
     info(f"fetch {npm_url}")
     data = fetch_json(npm_url)
     return [Version(data["version"])]
+
+
+def fetch_npm_snapshots(url: ParseResult, branch: str) -> list[Version]:
+    if url.netloc != "registry.npmjs.org":
+        return []
+    parts = url.path.split("/")
+    # Handle scoped packages like @myorg/mypackage
+    package = f"{parts[1]}/{parts[2]}" if parts[1].startswith("@") else parts[1]
+    npm_url = f"https://registry.npmjs.org/{package}/{branch}"
+    info(f"fetch {npm_url}")
+    data = fetch_json(npm_url)
+    return [Version(data["version"])]

--- a/tests/test_npm_fetch_latest_version.py
+++ b/tests/test_npm_fetch_latest_version.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import io
 import unittest.mock
 from typing import TYPE_CHECKING
+from urllib.error import HTTPError
 from urllib.parse import urlparse
+
+import pytest
 
 from nix_update.version import VersionFetchConfig, fetch_latest_version
 from nix_update.version.version import VersionPreference
@@ -22,6 +25,21 @@ def fake_npm_urlopen(request: Request, timeout: float | None = None) -> io.Bytes
 
     if url == "https://registry.npmjs.org/express/latest":
         return io.BytesIO(b'{"version": "4.21.2"}')
+
+    if url == "https://registry.npmjs.org/express/latest-4":
+        return io.BytesIO(b'{"version": "4.22.2"}')
+
+    if url == "https://registry.npmjs.org/@anthropic-ai/claude-code/next":
+        return io.BytesIO(b'{"version": "2.1.206"}')
+
+    if url == "https://registry.npmjs.org/express/missing":
+        raise HTTPError(
+            url,
+            404,
+            "Not Found",
+            None,
+            io.BytesIO(b'"version not found: missing"'),
+        )
 
     raise ValueError(f"Unexpected URL in test: {url}")  # noqa: EM102, TRY003
 
@@ -55,4 +73,54 @@ def test_regular_npm(helpers: conftest.Helpers) -> None:
                 ),
             ).number
             == "4.21.2"
+        )
+
+
+def test_npm_dist_tag(helpers: conftest.Helpers) -> None:
+    del helpers
+    with unittest.mock.patch("nix_update.version.http.urlopen", fake_npm_urlopen):
+        assert (
+            fetch_latest_version(
+                urlparse("https://registry.npmjs.org/express/-/express-4.21.1.tgz"),
+                VersionFetchConfig(
+                    preference=VersionPreference.BRANCH,
+                    version_regex="(.*)",
+                    branch="latest-4",
+                ),
+            ).number
+            == "4.22.2"
+        )
+
+
+def test_npm_scoped_dist_tag(helpers: conftest.Helpers) -> None:
+    del helpers
+    with unittest.mock.patch("nix_update.version.http.urlopen", fake_npm_urlopen):
+        assert (
+            fetch_latest_version(
+                urlparse(
+                    "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.42.tgz",
+                ),
+                VersionFetchConfig(
+                    preference=VersionPreference.BRANCH,
+                    version_regex="(.*)",
+                    branch="next",
+                ),
+            ).number
+            == "2.1.206"
+        )
+
+
+def test_npm_missing_dist_tag(helpers: conftest.Helpers) -> None:
+    del helpers
+    with (
+        unittest.mock.patch("nix_update.version.http.urlopen", fake_npm_urlopen),
+        pytest.raises(HTTPError),
+    ):
+        fetch_latest_version(
+            urlparse("https://registry.npmjs.org/express/-/express-4.21.1.tgz"),
+            VersionFetchConfig(
+                preference=VersionPreference.BRANCH,
+                version_regex="(.*)",
+                branch="missing",
+            ),
         )

--- a/tests/test_npm_fetch_latest_version.py
+++ b/tests/test_npm_fetch_latest_version.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import io
 import unittest.mock
 from typing import TYPE_CHECKING
-from urllib.error import HTTPError
 from urllib.parse import urlparse
-
-import pytest
 
 from nix_update.version import VersionFetchConfig, fetch_latest_version
 from nix_update.version.version import VersionPreference
@@ -31,15 +28,6 @@ def fake_npm_urlopen(request: Request, timeout: float | None = None) -> io.Bytes
 
     if url == "https://registry.npmjs.org/@anthropic-ai/claude-code/next":
         return io.BytesIO(b'{"version": "2.1.206"}')
-
-    if url == "https://registry.npmjs.org/express/missing":
-        raise HTTPError(
-            url,
-            404,
-            "Not Found",
-            None,
-            io.BytesIO(b'"version not found: missing"'),
-        )
 
     raise ValueError(f"Unexpected URL in test: {url}")  # noqa: EM102, TRY003
 
@@ -107,20 +95,4 @@ def test_npm_scoped_dist_tag(helpers: conftest.Helpers) -> None:
                 ),
             ).number
             == "2.1.206"
-        )
-
-
-def test_npm_missing_dist_tag(helpers: conftest.Helpers) -> None:
-    del helpers
-    with (
-        unittest.mock.patch("nix_update.version.http.urlopen", fake_npm_urlopen),
-        pytest.raises(HTTPError),
-    ):
-        fetch_latest_version(
-            urlparse("https://registry.npmjs.org/express/-/express-4.21.1.tgz"),
-            VersionFetchConfig(
-                preference=VersionPreference.BRANCH,
-                version_regex="(.*)",
-                branch="missing",
-            ),
         )


### PR DESCRIPTION
npm package variants are commonly distributed with a "dist-tag" which can be used to group releases ("latest", "beta", "next", etc...)

the npm version detector currently only supports updating to the latest release of the "latest" dist-tag

this PR augments the --version=branch flag to take a name as the dist-tag to update from (--version=branch=next will query https://registry.npmjs.org/<package\>/next)

tested and no currently passing tests fail after the changes