### PR TITLE
tests: fix failures caused by upstream drift

### DIFF
--- a/tests/test_version_prefix.py
+++ b/tests/test_version_prefix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from typing import TYPE_CHECKING
 
@@ -26,7 +27,13 @@ def test_main(testpkgs_git: Path) -> None:
         text=True,
         stdout=subprocess.PIPE,
     ).stdout.strip()
-    assert tuple(map(int, version.split("."))) >= (0, 9, 0)
+    # upstream tags may have non-numeric suffixes like "0.9.140-b.1"
+    numeric_version = tuple(
+        int(match.group())
+        for part in version.split(".")
+        if (match := re.match(r"\d+", part))
+    )
+    assert numeric_version >= (0, 9, 0)
     commit = subprocess.run(
         ["git", "-C", str(testpkgs_git), "log", "-1"],
         text=True,

--- a/tests/testpkgs/pnpm.nix
+++ b/tests/testpkgs/pnpm.nix
@@ -1,7 +1,7 @@
 {
   buildNpmPackage,
   fetchFromGitHub,
-  pnpm_9,
+  pnpm_10,
 }:
 
 buildNpmPackage rec {
@@ -15,11 +15,11 @@ buildNpmPackage rec {
     hash = "sha256-sIwXx9DA+vRW4pf6jyqcsla0khh8fdpvVTZ5pLrUhhc=";
   };
 
-  npmConfigHook = pnpm_9.configHook;
+  npmConfigHook = pnpm_10.configHook;
   npmDeps = pnpmDeps;
-  pnpmDeps = pnpm_9.fetchDeps {
+  pnpmDeps = pnpm_10.fetchDeps {
     inherit pname version src;
-    fetcherVersion = 3;
+    fetcherVersion = 4;
     hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
   };
 }


### PR DESCRIPTION
Fixes CI failures from upstream drift (see #640):

- `test_version_prefix`: nextest tags now have non-numeric suffixes (`0.9.140-b.1`); compare only leading digits.
- `test_pnpm`: new flood releases use a pnpm 10 lockfile; switch test package to `pnpm_10` with `fetcherVersion = 4`.