### PR TITLE
git: run diff in the package file's repository

### DIFF
--- a/nix_update/git.py
+++ b/nix_update/git.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 
 from .hashes import to_sri
 from .utils import run
@@ -41,13 +42,14 @@ def old_version_from_git(
     linenumber: int,
     new_version: str,
 ) -> str | None:
+    # Run in the file's directory: the file may live in a different
+    # repository than the current working directory.
     proc = run(
         ["git", "diff", "--color=never", "--word-diff=porcelain", "--", filename],
+        cwd=Path(filename).parent,
+        check=False,
     )
-    if proc.stdout is None:
-        msg = "Failed to get stdout from git diff command"
-        raise RuntimeError(msg)
-    if len(proc.stdout) == 0:
+    if proc.returncode != 0 or not proc.stdout:
         return None
     return old_version_from_diff(proc.stdout, linenumber, new_version)
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from nix_update.git import old_version_from_diff
+from nix_update.git import old_version_from_diff, old_version_from_git
 
 if TYPE_CHECKING:
+    import pytest
+
     from tests import conftest
 
 TEST_ROOT = Path(__file__).parent.resolve()
@@ -16,3 +19,47 @@ def test_worddiff(helpers: conftest.Helpers) -> None:
         diff = f.read()
         s = old_version_from_diff(diff, 5, "1.9.0")
         assert s == "1.8.6"
+
+
+def test_old_version_from_git_outside_cwd_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The file's own repository must be used, not the current working directory."""
+    cwd_repo = tmp_path / "cwd-repo"
+    pkg_repo = tmp_path / "pkg-repo"
+    cwd_repo.mkdir()
+    pkg_repo.mkdir()
+    for repo in (cwd_repo, pkg_repo):
+        subprocess.run(["git", "-C", repo, "init", "-q"], check=True)
+
+    pkg_file = pkg_repo / "package.nix"
+    pkg_file.write_text('{\n  version = "1.0.0";\n}\n')
+    subprocess.run(["git", "-C", pkg_repo, "add", "package.nix"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            pkg_repo,
+            "-c",
+            "user.name=nix-update",
+            "-c",
+            "user.email=nix-update@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "init",
+            "--no-gpg-sign",
+        ],
+        check=True,
+    )
+    pkg_file.write_text('{\n  version = "2.0.0";\n}\n')
+
+    monkeypatch.chdir(cwd_repo)
+    assert old_version_from_git(str(pkg_file), 2, "2.0.0") == "1.0.0"
+
+
+def test_old_version_from_git_no_repo(tmp_path: Path) -> None:
+    pkg_file = tmp_path / "package.nix"
+    pkg_file.write_text('version = "2.0.0";\n')
+    assert old_version_from_git(str(pkg_file), 1, "2.0.0") is None


### PR DESCRIPTION
old_version_from_git ran git diff from the current working directory,
which fails with 'is outside repository' when the package file lives in
a different repository (e.g. --file pointing at another checkout).
Run the diff from the file's directory and return None when the file is
not tracked by git.
