### PR TITLE
fix: skip unchanged versions without rev or tag

### DIFF
--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -28,7 +28,9 @@ def replace_version(package: Package) -> bool:
     new_version = new_version.removeprefix("v")
 
     changed = old_version != new_version or (
-        package.new_version.rev is not None and package.new_version.rev != old_rev_tag
+        old_rev_tag is not None
+        and package.new_version.rev is not None
+        and package.new_version.rev != old_rev_tag
     )
 
     if changed:

--- a/tests/test_replace_version.py
+++ b/tests/test_replace_version.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from nix_update.eval import eval_attr
+from nix_update.options import Options
+from nix_update.update import replace_version
+from nix_update.version.version import Version
+
+
+def test_same_version_without_rev_is_noop(testpkgs: Path) -> None:
+    # fetchurl-github-release pins neither rev nor tag, so a rev reported by
+    # the version fetcher has nothing to rewrite and must not count as a change.
+    package = eval_attr(
+        Options(attribute="fetchurl-github-release", import_path=str(testpkgs)),
+    )
+    assert package.rev is None
+    assert package.tag is None
+    package.new_version = Version(package.old_version, rev="deadbeef")
+    before = Path(package.filename).read_text()
+
+    assert not replace_version(package)
+    assert Path(package.filename).read_text() == before


### PR DESCRIPTION
## Minimal bug example

```nix
version = "1.16.0";
src = fetchurl {
  url = "https://github.com/Mic92/nix-update/archive/refs/tags/v${version}.tar.gz";
  hash = "sha256-j/e+TD1CHcaIXDmDMN79lj0Bah/7dLnFgJGt9BpnKCs=";
};
```

Run:

```console
nix-update --flake -f . repro --version-regex '^v(\d+\.\d+\.\d+)$'
```

Actual:

```text
Update 1.16.0 -> 1.16.0 in flake.nix
No changes detected, skipping remaining steps
```

Expected:

```text
Not updating version, already 1.16.0
No changes detected, skipping remaining steps
```