### PR TITLE
run passthru.updateScript in non-flake repos outside nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ Arguments can be passed to `nix-shell maintainers/scripts/update.nix` like so
 $ nix-update sbt --use-update-script --update-script-args "--argstr skip-prompt true"
 ```
 
+This also works outside of nixpkgs (with or without `--flake`). The script is
+executed from the repository root with `UPDATE_NIX_NAME`, `UPDATE_NIX_PNAME`,
+`UPDATE_NIX_OLD_VERSION` and `UPDATE_NIX_ATTR_PATH` set, e.g.:
+
+```nix
+passthru.updateScript = writeShellScript "update-mypkg" ''
+  sed -i "s/version = \"$UPDATE_NIX_OLD_VERSION\";/version = \"2.0.0\";/" mypkg.nix
+'';
+```
+
 In case your package has dependency fetchers with custom attribute names, you
 can pass them using `--custom-dep`:
 

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -137,12 +137,13 @@ def update_version(
 
 
 def run_update_script(package: Package, opts: Options) -> None:
-    if not opts.flake:
+    nixpkgs_update_nix = Path(opts.import_path) / "maintainers/scripts/update.nix"
+    if not opts.flake and nixpkgs_update_nix.exists():
         run(
             [
                 "nix-shell",
                 *opts.extra_flags,
-                str(Path(opts.import_path) / "maintainers/scripts/update.nix"),
+                str(nixpkgs_update_nix),
                 "--argstr",
                 "package",
                 opts.attribute,

--- a/tests/test_non_flake_use_update_script.py
+++ b/tests/test_non_flake_use_update_script.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+from nix_update import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_update(testpkgs_git: Path) -> None:
+    main(
+        [
+            "--file",
+            str(testpkgs_git),
+            "--use-update-script",
+            "--commit",
+            "non-flake-update-script",
+        ],
+    )
+
+    diff = subprocess.run(
+        ["git", "-C", str(testpkgs_git), "show"],
+        text=True,
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout.strip()
+    print(diff)
+    assert "non-flake-update-script: 1.0.0 -> 1.2.3" in diff
+    assert '+  version = "1.2.3";' in diff

--- a/tests/testpkgs/default.nix
+++ b/tests/testpkgs/default.nix
@@ -21,6 +21,7 @@
   crate = pkgs.callPackage ./crate.nix { };
   fetchurl-github-release = pkgs.callPackage ./fetchurl-github-release.nix { };
   flake-use-update-script = pkgs.callPackage ./flake-use-update-script.nix { };
+  non-flake-update-script = pkgs.callPackage ./non-flake-update-script.nix { };
   nuget-deps-generate = pkgs.callPackage ./nuget-deps-generate { };
   gitea = pkgs.callPackage ./gitea.nix { };
   github = pkgs.callPackage ./github.nix { };

--- a/tests/testpkgs/non-flake-update-script.nix
+++ b/tests/testpkgs/non-flake-update-script.nix
@@ -1,0 +1,18 @@
+{
+  stdenv,
+  writeShellScript,
+}:
+
+stdenv.mkDerivation {
+  pname = "non-flake-update-script";
+  version = "1.0.0";
+
+  src = ./.;
+
+  # A custom update script as an out-of-nixpkgs repo might ship it: it runs
+  # from the repo root and receives UPDATE_NIX_* from nix-update.
+  passthru.updateScript = writeShellScript "update-non-flake-update-script" ''
+    set -eu
+    sed -i "s/version = \"$UPDATE_NIX_OLD_VERSION\";/version = \"1.2.3\";/" non-flake-update-script.nix
+  '';
+}


### PR DESCRIPTION

The non-flake path unconditionally called nixpkgs'
maintainers/scripts/update.nix, so --use-update-script failed in any
plain default.nix repository. Fall back to the generic runner (build the
script, execute it with UPDATE_NIX_* set) when update.nix is absent.

Add a testpkgs example with a hand-written updateScript to cover it.
