### PR TITLE
re-evaluate package once after update

### DIFF
--- a/nix_update/__init__.py
+++ b/nix_update/__init__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import NoReturn
 
 from . import utils
-from .eval import CargoLockInSource, Package, eval_attr
+from .eval import CargoLockInSource, Package
 from .options import Options
 from .update import update
 from .utils import info, nix_command, run
@@ -456,9 +456,6 @@ def handle_commit_operations(
         if git_dir is None:
             msg = "Git directory not found, cannot commit changes"
             raise RuntimeError(msg)
-        if package.changelog:
-            # If we have a changelog we will re-eval the package in case it has changed
-            package.changelog = eval_attr(options).changelog
         git_commit(git_dir, package)
 
     if options.print_commit_message:

--- a/nix_update/diff_urls.py
+++ b/nix_update/diff_urls.py
@@ -6,10 +6,9 @@ import re
 from typing import TYPE_CHECKING
 
 from .errors import UpdateError
-from .eval import Package, eval_attr
 
 if TYPE_CHECKING:
-    from .options import Options
+    from .eval import Package
     from .version.version import Version
 
 GITLAB_API = re.compile(r"https://(gitlab.com|([^/]+)/api/v4)/")
@@ -61,8 +60,8 @@ def extract_github_rev_tag(url_path: str) -> str | None:
 
 
 def create_github_diff_url(
-    opts: Options,
     package: Package,
+    new_package: Package,
     new_version: Version,
 ) -> str | None:
     if package.parsed_url is None:
@@ -75,7 +74,6 @@ def create_github_diff_url(
 
     new_rev_tag = new_version.tag or new_version.rev
     if new_rev_tag is None:
-        new_package = eval_attr(opts)
         new_rev_tag = new_package.tag or new_package.rev
 
         if new_rev_tag is None and new_package.parsed_url is not None:
@@ -103,8 +101,9 @@ def create_other_diff_urls(package: Package, new_version: Version) -> str | None
     return None
 
 
-def generate_diff_url(opts: Options, package: Package, new_version: Version) -> None:
-    if not package.parsed_url:
+def generate_diff_url(package: Package, new_package: Package) -> None:
+    new_version = package.new_version
+    if not package.parsed_url or new_version is None:
         return
 
     netloc = package.parsed_url.netloc
@@ -115,7 +114,7 @@ def generate_diff_url(opts: Options, package: Package, new_version: Version) -> 
     elif netloc == "registry.npmjs.org":
         diff_url = create_npm_diff_url(package, new_version)
     elif netloc == "github.com":
-        diff_url = create_github_diff_url(opts, package, new_version)
+        diff_url = create_github_diff_url(package, new_package, new_version)
     else:
         diff_url = create_other_diff_urls(package, new_version)
 

--- a/nix_update/update.py
+++ b/nix_update/update.py
@@ -129,11 +129,7 @@ def update_version(
             package.old_version = recovered_version
             return False
 
-    if not replace_version(package):
-        return False
-
-    generate_diff_url(opts, package, new_version)
-    return True
+    return replace_version(package)
 
 
 def run_update_script(package: Package, opts: Options) -> None:
@@ -206,7 +202,7 @@ def update(opts: Options) -> Package:
             rev=new_package.rev,
             tag=new_package.tag,
         )
-
+        finalize(package, new_package)
         return package
 
     update_hash = True
@@ -237,4 +233,13 @@ def update(opts: Options) -> Package:
 
     update_dependency_hashes(opts, package, update_hash=update_hash)
 
+    if update_hash:
+        finalize(package, eval_attr(opts))
     return package
+
+
+def finalize(package: Package, new_package: Package) -> None:
+    """Refresh fields that depend on the updated expression (e.g. a
+    version-interpolated meta.changelog) from a single post-update eval."""
+    package.changelog = new_package.changelog
+    generate_diff_url(package, new_package)

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -38,3 +38,23 @@ def test_main(testpkgs_git: Path) -> None:
     assert (
         f"https://github.com/Mic92/python-mpd2/blob/{version}/doc/changes.rst" in commit
     )
+
+
+def test_write_commit_message(testpkgs: Path) -> None:
+    # Regression test for #657: changelog must reflect the new version even
+    # without --commit.
+    msg_file = testpkgs / "commit-msg"
+    main(
+        [
+            "--file",
+            str(testpkgs),
+            "--write-commit-message",
+            str(msg_file),
+            "pypi",
+        ],
+    )
+    msg = msg_file.read_text()
+    print(msg)
+    version = msg.splitlines()[0].split(" -> ")[1]
+    assert version != "2.0.0"
+    assert f"https://github.com/Mic92/python-mpd2/blob/{version}/doc/changes.rst" in msg


### PR DESCRIPTION
meta.changelog was only refreshed under --commit, so
--print/--write-commit-message showed the old release URL. Do one
eval_attr() at the end of update() and derive changelog and diff URL
from it.

Fixes #657
