### PR TITLE
github: don't handle Gitea/Forgejo hosts

### DIFF
--- a/nix_update/version/github.py
+++ b/nix_update/version/github.py
@@ -15,6 +15,7 @@ from xml.etree.ElementTree import Element, ParseError
 from nix_update.errors import VersionError
 from nix_update.utils import info, remove_control_chars
 
+from .gitea import is_gitea_host
 from .http import DEFAULT_TIMEOUT
 from .version import Version
 
@@ -26,6 +27,22 @@ GITHUB_PUBLIC_GENERAL = re.compile(r"^/(?P<owner>[^~]+?)/(?P<repo>.+?)(\.git)?(/
 GITHUB_PRIVATE = re.compile(
     r"^(/api/v3)?/repos/(?P<owner>[^~]+?)/(?P<repo>.+?)/tarball/(?P<revWithTag>.+)$",
 )
+
+
+def match_github_url(url: ParseResult) -> re.Match[str] | None:
+    if url.netloc == "github.com":
+        return (
+            GITHUB_PUBLIC.match(url.path)
+            or GITHUB_PRIVATE.match(url.path)
+            or GITHUB_PUBLIC_GENERAL.match(url.path)
+        )
+    # The archive/tarball patterns are host-agnostic to support GitHub
+    # Enterprise, but Gitea/Forgejo serve the same paths *and* a releases.atom
+    # that only lists releases, not tags. Leave those to the Gitea fetcher.
+    m = GITHUB_PUBLIC.match(url.path) or GITHUB_PRIVATE.match(url.path)
+    if m and is_gitea_host(url.netloc):
+        return None
+    return m
 
 
 def version_from_entry(entry: Element) -> Version:
@@ -77,11 +94,7 @@ def fetch_github_versions(
     url: ParseResult,
     extra_args: dict[str, Any] | None = None,
 ) -> list[Version]:
-    urlmatch = (
-        GITHUB_PUBLIC.match(url.path)
-        or GITHUB_PRIVATE.match(url.path)
-        or (url.netloc == "github.com" and GITHUB_PUBLIC_GENERAL.match(url.path))
-    )
+    urlmatch = match_github_url(url)
     if not urlmatch:
         return []
     owner, repo = urlmatch.group("owner"), urlmatch.group("repo")
@@ -161,11 +174,7 @@ def fetch_github_snapshots(
     branch: str,
     extra_args: dict[str, Any] | None = None,
 ) -> list[Version]:
-    urlmatch = (
-        GITHUB_PUBLIC.match(url.path)
-        or GITHUB_PRIVATE.match(url.path)
-        or (url.netloc == "github.com" and GITHUB_PUBLIC_GENERAL.match(url.path))
-    )
+    urlmatch = match_github_url(url)
     if not urlmatch:
         return []
     server = url.netloc

--- a/tests/test_gitea.py
+++ b/tests/test_gitea.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import subprocess
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from nix_update import main
+from nix_update.version import VersionFetchConfig, fetch_latest_version
+from nix_update.version.version import VersionPreference
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -40,3 +43,17 @@ def test_main(testpkgs_git: Path) -> None:
     assert version in commit
     assert "gitea" in commit
     assert "https://codeberg.org/nsxiv/nsxiv/compare/v29...v" in commit
+
+
+def test_tags_newer_than_releases() -> None:
+    # Regression test for #636: emacs-reader tags 0.3.1/0.3.2 have no Gitea
+    # release, so the GitHub-style releases.atom (which Codeberg also serves)
+    # must not be consulted or nix-update downgrades to 0.3.0.
+    url = urlparse(
+        "https://codeberg.org/MonadicSheep/emacs-reader/archive/0.3.2.tar.gz",
+    )
+    version = fetch_latest_version(
+        url,
+        VersionFetchConfig(VersionPreference.STABLE, "(.*)", old_rev_tag="0.3.2"),
+    )
+    assert tuple(map(int, version.number.split("."))) >= (0, 3, 2)


### PR DESCRIPTION
Codeberg serves GitHub-compatible archive URLs and a releases.atom that
lists only releases, so the GitHub fetcher matched first and picked an
older release over newer tags (0.3.2 -> 0.3.0 for emacs-reader).

Fixes #636
