### PR TITLE
ci: run workflows on gitea-mq batch branches

### DIFF
--- a/.github/workflows/cache-test-deps.yml
+++ b/.github/workflows/cache-test-deps.yml
@@ -6,8 +6,7 @@ on:
   push:
     branches:
       - main
-      - staging
-      - trying
+      - "gitea-mq/**"
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-      - staging
-      - trying
+      - "gitea-mq/**"
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The merge queue pushes gitea-mq/batch/* and waits for the required
checks, but Actions only triggered on the old bors branches, so batches
hung forever.
